### PR TITLE
fix: 세팅페이지, 주문접수 페이지 useIsFocuesd 추가 / 메뉴 업로드 필수 입력값 핸들링

### DIFF
--- a/src/components/menu/MenuModal.tsx
+++ b/src/components/menu/MenuModal.tsx
@@ -120,9 +120,28 @@ const MenuModal = ({
   };
 
   const handleSave = () => {
-    if (menuData) {
-      onSave(menuData);
+    const menuOriginPrice = Number(
+      menuData.originPrice.toString().replace(/,/g, ''),
+    );
+    const menuDiscountPrice = Number(
+      menuData.discountPrice.toString().replace(/,/g, ''),
+    );
+    const menuStock = Number(menuData.stock);
+    if (
+      !menuData.name.trim() ||
+      menuOriginPrice <= 0 ||
+      menuDiscountPrice <= 0 ||
+      menuStock < 0
+    ) {
+      Alert.alert('입력 오류', '필수 항목을 전부 올바르게 입력해주세요!');
+      return;
     }
+
+    if (menuOriginPrice < menuDiscountPrice) {
+      Alert.alert('가격 설정 오류', '할인가가 원가보다 클 수 없어요!');
+      return;
+    }
+    onSave(menuData);
   };
 
   const handleImageUpload = async () => {

--- a/src/screens/MyPageScreen/index.tsx
+++ b/src/screens/MyPageScreen/index.tsx
@@ -1,4 +1,4 @@
-import {useNavigation} from '@react-navigation/native';
+import {useNavigation, useIsFocused} from '@react-navigation/native';
 import {StackNavigationProp} from '@react-navigation/stack';
 import React, {useEffect, useState, useCallback} from 'react';
 import {
@@ -32,7 +32,7 @@ const MyPageScreen = () => {
 
   const {profile, fetch: fetchProfile, selectMarket, logout} = useProfile();
   const {market, fetch: fetchMemberMarkets} = useMarket();
-
+  const isFocused = useIsFocused();
   const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
 
   const {onRefresh, refreshing} = usePullDownRefresh(async () => {
@@ -58,15 +58,23 @@ const MyPageScreen = () => {
         console.log('앱이 백그라운드로 이동');
       }
     };
+
     const subscription = AppState.addEventListener(
       'change',
       handleAppStateChange,
     );
+
     return () => {
       console.log('AppState 이벤트 클린업');
       subscription.remove();
     };
   }, [initializeNotificationPermission]);
+
+  useEffect(() => {
+    if (isFocused) {
+      initializeNotificationPermission();
+    }
+  }, [isFocused, initializeNotificationPermission]);
 
   const handleNotificationSwitch = async () => {
     try {

--- a/src/screens/OrderHistoryScreen/PendingOrders.tsx
+++ b/src/screens/OrderHistoryScreen/PendingOrders.tsx
@@ -1,6 +1,6 @@
 import React, {useCallback, useEffect, useState} from 'react';
 import {RefreshControl, ScrollView} from 'react-native';
-
+import {useIsFocused} from '@react-navigation/native';
 import {getPendingOrderLists, updateOrderStatus} from '@/apis/Orders';
 import PendingOrder from '@/components/pendingOrder/PendingOrder';
 import useProfile from '@/hooks/useProfile';
@@ -19,7 +19,7 @@ type PendingOrdersProps = {
 
 const PendingOrders = ({orderStatus}: PendingOrdersProps) => {
   const [orders, setOrders] = useState<OrderDetailInfoType[]>([]);
-
+  const isFocused = useIsFocused();
   const {profile} = useProfile();
 
   const fetchOrders = useCallback(async () => {
@@ -36,7 +36,9 @@ const PendingOrders = ({orderStatus}: PendingOrdersProps) => {
   const {onRefresh, refreshing} = usePullDownRefresh(fetchOrders);
 
   useEffect(() => {
-    fetchOrders();
+    if (isFocused) {
+      fetchOrders();
+    }
   }, [fetchOrders]);
 
   const handleStatusChange = (

--- a/src/screens/OrderHistoryScreen/PendingOrders.tsx
+++ b/src/screens/OrderHistoryScreen/PendingOrders.tsx
@@ -39,7 +39,7 @@ const PendingOrders = ({orderStatus}: PendingOrdersProps) => {
     if (isFocused) {
       fetchOrders();
     }
-  }, [fetchOrders]);
+  }, [fetchOrders, isFocused]);
 
   const handleStatusChange = (
     orderId: string,


### PR DESCRIPTION
## 📝작업 내용

- 주문접수 페이지에서 주문 들어왔을 때 페이지 렌더링이 잘 되지 않아 useIsFocuesd 적용했습니다.
- 세팅페이지 useIsFocused 적용했습니다.
- 현재 메뉴 업로드시 아무것도 입력하지 않아도 저장이 되어 프론트단에서 onSave 이전에 핸들링했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
에러 핸들링 방식 맞는지 컨펌 부탁드립니다..!
