### PR TITLE
fix: 주문 번호 6자리 해쉬값 적용

### DIFF
--- a/src/components/orderDetail/OrderCustomerInfo.tsx
+++ b/src/components/orderDetail/OrderCustomerInfo.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import S from './OrderCustomerInfo.style';
 
 import {format} from '@/utils/date';
-
+import {to6DigitHash} from '@/utils/hash';
 type Props = {
   id: string;
   orderMemberName: string;
@@ -20,7 +20,7 @@ const OrderCustomerInfo = ({
 }: Props) => {
   return (
     <S.Container>
-      <S.InfoText>주문번호: {id}</S.InfoText>
+      <S.InfoText>주문번호: {to6DigitHash(id)}</S.InfoText>
       <S.InfoText>주문자명: {orderMemberName}</S.InfoText>
       <S.InfoText>
         {`주문 일시: ${format(new Date(createdAt).getTime(), 'YYYY. MM. DD. (ddd) A hh:mm')}`}

--- a/src/components/pendingOrder/PendingOrder.tsx
+++ b/src/components/pendingOrder/PendingOrder.tsx
@@ -6,6 +6,7 @@ import {StackNavigationProp} from '@react-navigation/stack';
 import React from 'react';
 import {Text} from 'react-native';
 import S from './PendingOrder.style';
+import {to6DigitHash} from '@/utils/hash';
 
 type Props = {
   order: OrderDetailInfoType;
@@ -105,7 +106,7 @@ const PendingOrder = ({order, onStatusChange}: Props) => {
         </S.TimeInfo>
       </S.TimeInfoContainer>
       <S.DetailContainer>
-        <S.TextStyled>주문번호: {order.id.slice(0, 8)}</S.TextStyled>
+        <S.TextStyled>주문번호: {to6DigitHash(order.id)}</S.TextStyled>
         <S.TextStyled>주문자명: {order.orderMemberName}</S.TextStyled>
         {/* <S.RequestText>요청사항</S.RequestText>
         <Text numberOfLines={3} ellipsizeMode="tail">

--- a/src/screens/OrderDetailScreen/OrderDetailScreen.style.tsx
+++ b/src/screens/OrderDetailScreen/OrderDetailScreen.style.tsx
@@ -2,11 +2,11 @@ import styled from '@emotion/native';
 
 const Container = styled.ScrollView`
   flex: 1;
-  margin: 0 16px;
+  background-color: white;
 `;
 
 const HorizonDivider = styled.View`
-  border: 1px solid #e2e2e2;
+  border: 3px solid #e2e2e2;
   width: 100%;
 `;
 

--- a/src/screens/OrderHistoryScreen/OrderHistoryScreen.style.tsx
+++ b/src/screens/OrderHistoryScreen/OrderHistoryScreen.style.tsx
@@ -15,7 +15,7 @@ const ToggleText = styled.Text`
 `;
 
 const PendingOrderScreenContainer = styled.ScrollView`
-  margin-bottom: 72px;
+  margin-bottom: 36px;
 `;
 
 const S = {NavbarGroup, ToggleText, PendingOrderScreenContainer};

--- a/src/screens/OrderHistoryScreen/OrderHistoryScreen.style.tsx
+++ b/src/screens/OrderHistoryScreen/OrderHistoryScreen.style.tsx
@@ -14,6 +14,10 @@ const ToggleText = styled.Text`
   color: ${props => props.theme.colors.tertiary};
 `;
 
-const S = {NavbarGroup, ToggleText};
+const PendingOrderScreenContainer = styled.ScrollView`
+  margin-bottom: 72px;
+`;
+
+const S = {NavbarGroup, ToggleText, PendingOrderScreenContainer};
 
 export default S;

--- a/src/screens/OrderHistoryScreen/index.tsx
+++ b/src/screens/OrderHistoryScreen/index.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import {View, ScrollView} from 'react-native';
+import {View} from 'react-native';
 
 import {ToggleButton} from '@/components/common';
 import EmptyMarket from '@/components/common/EmptyMarket';

--- a/src/screens/OrderHistoryScreen/index.tsx
+++ b/src/screens/OrderHistoryScreen/index.tsx
@@ -42,9 +42,9 @@ const OrderHistoryScreen = () => {
           <S.ToggleText>{`완료/취소`}</S.ToggleText>
         </ToggleButton>
       </S.NavbarGroup>
-      <ScrollView>
+      <S.PendingOrderScreenContainer>
         <PendingOrdersScreen orderStatus={selected} />
-      </ScrollView>
+      </S.PendingOrderScreenContainer>
     </View>
   );
 };

--- a/src/screens/OrderHistoryScreen/index.tsx
+++ b/src/screens/OrderHistoryScreen/index.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import {View} from 'react-native';
+import {View, ScrollView} from 'react-native';
 
 import {ToggleButton} from '@/components/common';
 import EmptyMarket from '@/components/common/EmptyMarket';
@@ -42,9 +42,9 @@ const OrderHistoryScreen = () => {
           <S.ToggleText>{`완료/취소`}</S.ToggleText>
         </ToggleButton>
       </S.NavbarGroup>
-      <View>
+      <ScrollView>
         <PendingOrdersScreen orderStatus={selected} />
-      </View>
+      </ScrollView>
     </View>
   );
 };

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -1,0 +1,24 @@
+/* eslint-disable no-bitwise */
+const crcTable = new Uint32Array(256);
+for (let i = 0; i < 256; i++) {
+  let crc = i;
+  for (let j = 0; j < 8; j++) {
+    crc = crc & 1 ? (crc >>> 1) ^ 0xedb88320 : crc >>> 1;
+  }
+  crcTable[i] = crc;
+}
+
+const crc32 = (str: string): number => {
+  let crc = 0xffffffff;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    crc = (crc >>> 8) ^ crcTable[(crc ^ char) & 0xff];
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+};
+
+// 6자리 해시 생성 함수
+export const to6DigitHash = (str: string): string => {
+  const crc = crc32(str).toString(16);
+  return crc.slice(0, 6).toUpperCase();
+};


### PR DESCRIPTION
## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 클라앱과 동일한 해쉬함수 적용했습니다.
- orderDetail 페이지 배경만 바꿨습니다.
### 스크린샷 (선택)
  <img src="https://github.com/user-attachments/assets/028d8db9-0c73-43d3-8154-61e5bf6fca8c" alt="Image 1" width="45%">
  <img src="https://github.com/user-attachments/assets/3c6b65b4-98ea-4c94-83cf-77fdb6c261f6" alt="Image 2" width="45%">

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
