### PR TITLE
fix: fcm 로직 변경 및 리팩토링

### DIFF
--- a/src/apis/fcm.ts
+++ b/src/apis/fcm.ts
@@ -1,5 +1,4 @@
 import apiClient from './ApiClient';
-
 export const registerFCMToken = async (
   deviceToken: string,
 ): Promise<boolean> => {

--- a/src/utils/notification.ts
+++ b/src/utils/notification.ts
@@ -4,18 +4,19 @@ import {registerFCMToken} from '@/apis/fcm';
 import {PermissionsAndroid, Platform, Alert, Linking} from 'react-native';
 
 export const requestNotificationPermission = async () => {
-  const authStatus = await messaging().requestPermission();
-  console.log(authStatus);
-  if (
-    authStatus === messaging.AuthorizationStatus.AUTHORIZED ||
-    authStatus === messaging.AuthorizationStatus.PROVISIONAL
-  ) {
-    console.log('fcm 권한 허용', authStatus);
-  } else {
-    console.log('fcm 권한 거부됨', authStatus);
-    return;
-  }
-  if (Platform.OS === 'android' && Platform.Version >= 33) {
+  if (Platform.OS === 'ios') {
+    const authStatus = await messaging().requestPermission();
+    console.log(authStatus);
+    if (
+      authStatus === messaging.AuthorizationStatus.AUTHORIZED ||
+      authStatus === messaging.AuthorizationStatus.PROVISIONAL
+    ) {
+      console.log('fcm 권한 허용', authStatus);
+    } else {
+      console.log('fcm 권한 거부됨', authStatus);
+      return;
+    }
+  } else if (Platform.OS === 'android') {
     const androidPermission = await requestAndroidPermission();
     if (!androidPermission) {
       console.log('Android POST_NOTIFICATIONS 권한 거부됨');
@@ -28,19 +29,28 @@ export const requestNotificationPermission = async () => {
   console.log('FCM Token:', token);
 };
 
-export const isNotificationPermissionEnabled = async (): Promise<boolean> => {
+const isIOSNotificationPermissionEnabled = async (): Promise<boolean> => {
   const status = await messaging().hasPermission();
-  const AndroidPermssionStatus: boolean =
-    Platform.OS === 'android' && Platform.Version >= 33
-      ? await PermissionsAndroid.check(
-          PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS,
-        )
-      : true;
   return (
-    AndroidPermssionStatus &&
-    (status === messaging.AuthorizationStatus.AUTHORIZED ||
-      status === messaging.AuthorizationStatus.PROVISIONAL)
+    status === messaging.AuthorizationStatus.AUTHORIZED ||
+    status === messaging.AuthorizationStatus.PROVISIONAL
   );
+};
+
+const isAndroidNotificationPermissionEnabled = async (): Promise<boolean> => {
+  const androidPermission = await PermissionsAndroid.check(
+    PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS,
+  );
+  return androidPermission;
+};
+
+export const isNotificationPermissionEnabled = async (): Promise<boolean> => {
+  if (Platform.OS === 'ios') {
+    return await isIOSNotificationPermissionEnabled();
+  } else if (Platform.OS === 'android') {
+    return await isAndroidNotificationPermissionEnabled();
+  }
+  return false;
 };
 
 const requestAndroidPermission = async (): Promise<boolean> => {
@@ -102,7 +112,13 @@ const setUpPushNotificationHandlers = () => {
 };
 
 const displayNotification = async (remoteMessage: any) => {
-  const {title, body} = remoteMessage.notification ?? {};
+  let title = remoteMessage.notification?.title;
+  let body = remoteMessage.notification?.body;
+
+  if (!title && !body) {
+    title = remoteMessage.data?.title || '맘찬픽';
+    body = remoteMessage.data?.body || '새로운 알림이 있습니다.';
+  }
 
   const notificationOptions = {
     title,


### PR DESCRIPTION
## 📝작업 내용
- fcm 권한 설정 관련해서 로직 변경했습니다.
앱 스플래시 스크린에서 권한 있을시 fcm 토큰 항상 post하도록 일단 진행했습니다.
제 폰에서 고객주문 -> 상단바 알림 확인했습니다.

- foreground 상태에서 알림 오지 않아 핸들링했습니다.
### 스크린샷 (선택)
| foreground | background |
|------------|------------|
| ![image](https://github.com/user-attachments/assets/e9345bca-ebe4-4a53-906e-3ecde6289e32) | ![image](https://github.com/user-attachments/assets/65c8354b-8e90-46f9-8300-74f6713a78a3) |

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
