### PR TITLE
feat: 가게 직원 조회, 해고 기능 추가 및 github actions cache version up

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
         run: echo "CACHE_DIR=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
       - name: Yarn cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.CACHE_DIR }}

--- a/src/apis/managers/model.ts
+++ b/src/apis/managers/model.ts
@@ -1,7 +1,7 @@
 import {ManagerInfo} from '@/types/Managers';
 
 export type DeleteManagerRequest = {
-  marketId: number;
+  marketId: number | null;
   memberId: number;
 };
 

--- a/src/apis/managers/model.ts
+++ b/src/apis/managers/model.ts
@@ -1,7 +1,7 @@
 import {ManagerInfo} from '@/types/Managers';
 
 export type DeleteManagerRequest = {
-  marketId: number | null;
+  marketId: number;
   memberId: number;
 };
 

--- a/src/apis/managers/query.ts
+++ b/src/apis/managers/query.ts
@@ -33,7 +33,7 @@ export const useDeleteManager = ({
   });
 };
 
-export const useReadManagers = (marketId: number) => {
+export const useReadManagers = (marketId: number | undefined | null) => {
   return useQuery({
     queryKey: ['readManagers', marketId],
     queryFn: () => {

--- a/src/components/manager/ManagerDeleteButton.style.tsx
+++ b/src/components/manager/ManagerDeleteButton.style.tsx
@@ -1,0 +1,47 @@
+import styled from '@emotion/native';
+
+const S = {
+  DeleteButton: styled.TouchableOpacity`
+    flex: 1;
+    align-items: center;
+    justify-content: center;
+  `,
+  DeleteText: styled.Text`
+    color: red;
+  `,
+  ModalContainer: styled.View`
+    display: flex;
+    flex-direction: column;
+    border-radius: 20px;
+    margin: 16px;
+    background-color: #ffffff;
+  `,
+
+  ModalHeader: styled.View`
+    display: flex;
+    flex-direction: row;
+
+    justify-content: center;
+    align-items: center;
+
+    height: 64px;
+
+    padding: 16px;
+
+    border-top-left-radius: 20px;
+    border-top-right-radius: 20px;
+
+    background-color: white;
+
+    box-sizing: border-box;
+  `,
+  ModalHeaderText: styled.Text``,
+  ModalFooter: styled.View`
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+  `,
+};
+
+export default S;

--- a/src/components/manager/ManagerDeleteButton.tsx
+++ b/src/components/manager/ManagerDeleteButton.tsx
@@ -5,7 +5,7 @@ import {useQueryClient} from '@tanstack/react-query';
 import {useDeleteManager} from '@/apis/managers';
 
 type ManagerDeleteButtonProps = {
-  marketId: number | null;
+  marketId: number;
   memberId: number;
 };
 
@@ -14,10 +14,6 @@ const ManagerDeleteButton = ({
   memberId,
 }: ManagerDeleteButtonProps) => {
   const queryClient = useQueryClient();
-
-  if (!marketId) {
-    return;
-  }
   const {mutateAsync: mutateDeleteManager} = useDeleteManager({
     marketId,
     memberId,

--- a/src/components/manager/ManagerDeleteButton.tsx
+++ b/src/components/manager/ManagerDeleteButton.tsx
@@ -14,6 +14,10 @@ const ManagerDeleteButton = ({
   memberId,
 }: ManagerDeleteButtonProps) => {
   const queryClient = useQueryClient();
+
+  if (!marketId) {
+    return;
+  }
   const {mutateAsync: mutateDeleteManager} = useDeleteManager({
     marketId,
     memberId,

--- a/src/components/manager/ManagerDeleteButton.tsx
+++ b/src/components/manager/ManagerDeleteButton.tsx
@@ -1,0 +1,58 @@
+import React, {useState} from 'react';
+import {Portal, Modal, Button} from 'react-native-paper';
+import S from './ManagerDeleteButton.style';
+import {useQueryClient} from '@tanstack/react-query';
+import {useDeleteManager} from '@/apis/managers';
+
+type ManagerDeleteButtonProps = {
+  marketId: number | null;
+  memberId: number;
+};
+
+const ManagerDeleteButton = ({
+  marketId,
+  memberId,
+}: ManagerDeleteButtonProps) => {
+  const queryClient = useQueryClient();
+  const {mutateAsync: mutateDeleteManager} = useDeleteManager({
+    marketId,
+    memberId,
+  });
+  const [visible, setVisible] = useState(false);
+
+  const showModal = () => setVisible(true);
+  const hideModal = () => setVisible(false);
+
+  const handleDeletePress = async () => {
+    if (marketId !== undefined) {
+      const res = await mutateDeleteManager();
+      if (res) {
+        queryClient.invalidateQueries({queryKey: ['readManagers', marketId]});
+      }
+    }
+    hideModal();
+  };
+
+  return (
+    <>
+      <S.DeleteButton onPress={showModal}>
+        <S.DeleteText>해고하기</S.DeleteText>
+      </S.DeleteButton>
+      <Portal>
+        <Modal visible={visible} onDismiss={hideModal}>
+          <S.ModalContainer>
+            <S.ModalHeader>
+              <S.ModalHeaderText>해고하시겠습니까?</S.ModalHeaderText>
+            </S.ModalHeader>
+            <S.ModalFooter>
+              <Button onPress={handleDeletePress}>확인</Button>
+              <Button onPress={hideModal}>취소</Button>
+            </S.ModalFooter>
+          </S.ModalContainer>
+        </Modal>
+      </Portal>
+    </>
+  );
+};
+
+export default ManagerDeleteButton;

--- a/src/components/manager/ManagerDeleteButton.tsx
+++ b/src/components/manager/ManagerDeleteButton.tsx
@@ -36,7 +36,7 @@ const ManagerDeleteButton = ({
   return (
     <>
       <S.DeleteButton onPress={showModal}>
-        <S.DeleteText>해고하기</S.DeleteText>
+        <S.DeleteText>삭제하기</S.DeleteText>
       </S.DeleteButton>
       <Portal>
         <Modal visible={visible} onDismiss={hideModal}>

--- a/src/components/manager/ManagerList.style.tsx
+++ b/src/components/manager/ManagerList.style.tsx
@@ -1,0 +1,30 @@
+import styled from '@emotion/native';
+
+const S = {
+  ListContainer: styled.View`
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom-width: 1px;
+    border-bottom-color: #ccc;
+  `,
+  NameText: styled.Text`
+    flex: 1;
+    text-align: center;
+  `,
+  RoleText: styled.Text`
+    flex: 1;
+    text-align: center;
+  `,
+  DeleteButton: styled.TouchableOpacity`
+    flex: 1;
+    align-items: center;
+    justify-content: center;
+    padding: 5px;
+  `,
+  DeleteText: styled.Text`
+    color: red;
+  `,
+};
+
+export default S;

--- a/src/components/manager/ManagerList.style.tsx
+++ b/src/components/manager/ManagerList.style.tsx
@@ -2,11 +2,10 @@ import styled from '@emotion/native';
 
 const S = {
   ListContainer: styled.View`
+    display: flex;
     flex-direction: row;
-    justify-content: space-between;
     align-items: center;
-    border-bottom-width: 1px;
-    border-bottom-color: #ccc;
+    padding: 8px 0px;
   `,
   NameText: styled.Text`
     flex: 1;
@@ -20,10 +19,12 @@ const S = {
     flex: 1;
     align-items: center;
     justify-content: center;
-    padding: 5px;
   `,
   DeleteText: styled.Text`
     color: red;
+  `,
+  EmptyPlaceholder: styled.View`
+    flex: 1;
   `,
 };
 

--- a/src/components/manager/ManagerList.tsx
+++ b/src/components/manager/ManagerList.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import S from './ManagerList.style';
+import ManagerDeleteButton from './ManagerDeleteButton';
 
 type ManagerListProps = {
-  id: number;
+  memberId: number;
+  marketId: number | null;
   name: string;
   marketRole: 'ROLE_STORE_OWNER' | 'ROLE_STORE_MANAGER';
-  createdAt: string;
 };
 
 const getRoleLabel = (
@@ -14,13 +15,12 @@ const getRoleLabel = (
   return role === 'ROLE_STORE_OWNER' ? '사장' : '직원';
 };
 
-const ManagerList = ({id, name, marketRole, createdAt}: ManagerListProps) => {
-  const handleDelete = async () => {
-    try {
-    } catch (error) {
-      console.error(error);
-    }
-  };
+const ManagerList = ({
+  marketId,
+  memberId,
+  name,
+  marketRole,
+}: ManagerListProps) => {
   const role = getRoleLabel(marketRole);
 
   return (
@@ -28,9 +28,7 @@ const ManagerList = ({id, name, marketRole, createdAt}: ManagerListProps) => {
       <S.NameText>{name}</S.NameText>
       <S.RoleText>{role}</S.RoleText>
       {role === '직원' ? (
-        <S.DeleteButton onPress={handleDelete}>
-          <S.DeleteText>삭제하기</S.DeleteText>
-        </S.DeleteButton>
+        <ManagerDeleteButton marketId={marketId} memberId={memberId} />
       ) : (
         <S.EmptyPlaceholder />
       )}

--- a/src/components/manager/ManagerList.tsx
+++ b/src/components/manager/ManagerList.tsx
@@ -9,10 +9,9 @@ type ManagerListProps = {
   marketRole: 'ROLE_STORE_OWNER' | 'ROLE_STORE_MANAGER';
 };
 
-const getRoleLabel = (
-  role: 'ROLE_STORE_OWNER' | 'ROLE_STORE_MANAGER',
-): string => {
-  return role === 'ROLE_STORE_OWNER' ? '사장' : '직원';
+const ROLE_LABELS: Record<'ROLE_STORE_OWNER' | 'ROLE_STORE_MANAGER', string> = {
+  ROLE_STORE_OWNER: '사장',
+  ROLE_STORE_MANAGER: '직원',
 };
 
 const ManagerList = ({
@@ -21,7 +20,7 @@ const ManagerList = ({
   name,
   marketRole,
 }: ManagerListProps) => {
-  const role = getRoleLabel(marketRole);
+  const role = ROLE_LABELS[marketRole];
 
   return (
     <S.ListContainer>

--- a/src/components/manager/ManagerList.tsx
+++ b/src/components/manager/ManagerList.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import S from './ManagerList.style';
+
+type ManagerListProps = {
+  id: number;
+  name: string;
+  marketRole: 'ROLE_STORE_OWNER' | 'ROLE_STORE_MANAGER';
+  createdAt: string;
+};
+
+const getRoleLabel = (
+  role: 'ROLE_STORE_OWNER' | 'ROLE_STORE_MANAGER',
+): string => {
+  return role === 'ROLE_STORE_OWNER' ? '사장' : '직원';
+};
+
+const ManagerList = ({id, name, marketRole, createdAt}: ManagerListProps) => {
+  const handleDelete = async () => {
+    try {
+    } catch (error) {
+      console.error(error);
+    }
+  };
+  const role = getRoleLabel(marketRole);
+  return (
+    <S.ListContainer>
+      <S.NameText>{name}</S.NameText>
+      <S.RoleText>{role}</S.RoleText>
+      {role !== '사장' && (
+        <S.DeleteButton onPress={handleDelete}>
+          <S.DeleteText>삭제하기</S.DeleteText>
+        </S.DeleteButton>
+      )}
+    </S.ListContainer>
+  );
+};
+
+export default ManagerList;

--- a/src/components/manager/ManagerList.tsx
+++ b/src/components/manager/ManagerList.tsx
@@ -20,6 +20,9 @@ const ManagerList = ({
   name,
   marketRole,
 }: ManagerListProps) => {
+  if (!marketId) {
+    marketId = 0;
+  }
   const role = ROLE_LABELS[marketRole];
 
   return (

--- a/src/components/manager/ManagerList.tsx
+++ b/src/components/manager/ManagerList.tsx
@@ -22,14 +22,17 @@ const ManagerList = ({id, name, marketRole, createdAt}: ManagerListProps) => {
     }
   };
   const role = getRoleLabel(marketRole);
+
   return (
     <S.ListContainer>
       <S.NameText>{name}</S.NameText>
       <S.RoleText>{role}</S.RoleText>
-      {role !== '사장' && (
+      {role === '직원' ? (
         <S.DeleteButton onPress={handleDelete}>
           <S.DeleteText>삭제하기</S.DeleteText>
         </S.DeleteButton>
+      ) : (
+        <S.EmptyPlaceholder />
       )}
     </S.ListContainer>
   );

--- a/src/components/manager/ManagerLists.style.tsx
+++ b/src/components/manager/ManagerLists.style.tsx
@@ -5,6 +5,7 @@ const S = {
     flex: 1;
     background-color: white;
     padding: 20px;
+    margin-top: 8px;
   `,
   HeaderRow: styled.View`
     flex-direction: row;

--- a/src/components/manager/ManagerLists.style.tsx
+++ b/src/components/manager/ManagerLists.style.tsx
@@ -1,0 +1,22 @@
+import styled from '@emotion/native';
+
+const S = {
+  ListsContainer: styled.View`
+    flex: 1;
+    background-color: white;
+    padding: 20px;
+  `,
+  HeaderRow: styled.View`
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+  `,
+  HeaderText: styled.Text`
+    flex: 1;
+    font-weight: bold;
+    text-align: center;
+  `,
+};
+
+export default S;

--- a/src/components/manager/ManagerLists.tsx
+++ b/src/components/manager/ManagerLists.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import S from './ManagerLists.style';
+import ManagerList from './ManagerList';
+import {ManagerInfo} from '@/types/Managers';
+
+type ManagerListsProps = {
+  managers?: ManagerInfo[];
+};
+
+const ManagerLists = ({managers}: ManagerListsProps) => {
+  return (
+    <S.ListsContainer>
+      {/* 헤더 영역 */}
+      <S.HeaderRow>
+        <S.HeaderText>이름</S.HeaderText>
+        <S.HeaderText>직책</S.HeaderText>
+        <S.HeaderText>해고하기</S.HeaderText>
+      </S.HeaderRow>
+
+      {/* 리스트 영역 */}
+      {managers?.map(manager => (
+        <ManagerList
+          key={manager.id}
+          id={manager.id}
+          name={manager.name}
+          marketRole={manager.marketRole}
+          createdAt={manager.createdAt}
+        />
+      ))}
+    </S.ListsContainer>
+  );
+};
+
+export default ManagerLists;

--- a/src/components/manager/ManagerLists.tsx
+++ b/src/components/manager/ManagerLists.tsx
@@ -11,14 +11,12 @@ type ManagerListsProps = {
 const ManagerLists = ({managers, marketId}: ManagerListsProps) => {
   return (
     <S.ListsContainer>
-      {/* 헤더 영역 */}
       <S.HeaderRow>
         <S.HeaderText>이름</S.HeaderText>
         <S.HeaderText>직책</S.HeaderText>
         <S.HeaderText>해고하기</S.HeaderText>
       </S.HeaderRow>
 
-      {/* 리스트 영역 */}
       {managers?.map(manager => (
         <ManagerList
           key={manager.id}

--- a/src/components/manager/ManagerLists.tsx
+++ b/src/components/manager/ManagerLists.tsx
@@ -14,7 +14,7 @@ const ManagerLists = ({managers, marketId}: ManagerListsProps) => {
       <S.HeaderRow>
         <S.HeaderText>이름</S.HeaderText>
         <S.HeaderText>직책</S.HeaderText>
-        <S.HeaderText>해고하기</S.HeaderText>
+        <S.HeaderText>삭제하기</S.HeaderText>
       </S.HeaderRow>
 
       {managers?.map(manager => (

--- a/src/components/manager/ManagerLists.tsx
+++ b/src/components/manager/ManagerLists.tsx
@@ -4,10 +4,11 @@ import ManagerList from './ManagerList';
 import {ManagerInfo} from '@/types/Managers';
 
 type ManagerListsProps = {
-  managers?: ManagerInfo[];
+  managers: ManagerInfo[] | null | undefined;
+  marketId: number | null;
 };
 
-const ManagerLists = ({managers}: ManagerListsProps) => {
+const ManagerLists = ({managers, marketId}: ManagerListsProps) => {
   return (
     <S.ListsContainer>
       {/* 헤더 영역 */}
@@ -21,10 +22,10 @@ const ManagerLists = ({managers}: ManagerListsProps) => {
       {managers?.map(manager => (
         <ManagerList
           key={manager.id}
-          id={manager.id}
+          memberId={manager.id}
+          marketId={marketId}
           name={manager.name}
           marketRole={manager.marketRole}
-          createdAt={manager.createdAt}
         />
       ))}
     </S.ListsContainer>

--- a/src/screens/MarketInfoScreen/MarketInfoScreen.style.tsx
+++ b/src/screens/MarketInfoScreen/MarketInfoScreen.style.tsx
@@ -14,7 +14,6 @@ const S = {
   TimeContainer: styled.View`
     display: flex;
     flex-direction: row;
-
     align-items: center;
     justify-content: center;
   `,

--- a/src/screens/MarketInfoScreen/index.tsx
+++ b/src/screens/MarketInfoScreen/index.tsx
@@ -137,7 +137,7 @@ const MarketInfoScreen = () => {
         </S.TimeContainer>
 
         <Label label={'직원 목록'} />
-        <ManagerLists managers={managersInfo} />
+        <ManagerLists managers={managersInfo} marketId={profile?.marketId} />
         {/* TODO: 대표 사진 선택 */}
         {/* <Label label={'대표 사진 선택'} required />
         <S.ImageCardGrid>

--- a/src/screens/MarketInfoScreen/index.tsx
+++ b/src/screens/MarketInfoScreen/index.tsx
@@ -19,6 +19,8 @@ import {format} from '@/utils/date';
 
 import {useQueryClient} from '@tanstack/react-query';
 import S from './MarketInfoScreen.style';
+import {useReadManagers} from '@/apis/managers';
+import ManagerLists from '@/components/manager/ManagerLists';
 
 const timeOptions = {
   'market-open': '영업 시작 시간',
@@ -32,6 +34,7 @@ const MarketInfoScreen = () => {
 
   const queryClient = useQueryClient();
   const {data: marketInfo} = useMarket(profile?.marketId);
+  const {data: managersInfo} = useReadManagers(profile?.marketId);
 
   const {refreshing, onRefresh} = usePullDownRefresh(async () => {
     await queryClient.invalidateQueries({
@@ -132,6 +135,9 @@ const MarketInfoScreen = () => {
               : timeOptions['pickup-end']}
           </S.TimePickerButton>
         </S.TimeContainer>
+
+        <Label label={'직원 목록'} />
+        <ManagerLists managers={managersInfo} />
         {/* TODO: 대표 사진 선택 */}
         {/* <Label label={'대표 사진 선택'} required />
         <S.ImageCardGrid>


### PR DESCRIPTION
## #️⃣연관된 이슈

resolves: #90 

<!-- resolves: #이슈번호, #이슈번호 -->

## 📝작업 내용

사장님 입장 로직 두가지 기능 작성했습니다.

직원 개념 기능 한번에 올리면 덩치가 너무 커질 것 같아
브랜치에서 분기하여 차후 기능 작성하여 pr 올리겠습니다.
남은 기능 하단 TODO에 작성하겠습니다.

- 가게 직원 조회
- 가게 직원 삭제


actions cache version up 했습니다.
[참조](https://github.com/ummgoban/admin-client-app/actions/runs/13644262215)
[참조2](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down)

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷 (선택)

https://github.com/user-attachments/assets/4dc2c50a-4b35-4eed-aa04-b29474e03b7d

## 💬리뷰 요구사항(선택)


### TODO

공통
- 사장과 직원 권한에 따른 뷰 분리

사장님 입장
- 가게 인증 코드 생성
- 인증 코드 입력한 직원 조회
- 인증 코드 입력한 직원 실제 등록

직원 입장
- 가게 인증 코드 입력
- 인증 되었을 때 알림(백에서 처리?)



<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
