### PR TITLE
feat: 직원 등록 로직 추가

### DIFF
--- a/src/apis/managers/client.ts
+++ b/src/apis/managers/client.ts
@@ -74,7 +74,7 @@ export const createManager = async (marketId: number): Promise<boolean> => {
   }
 };
 
-// FIXME: 에러 핸들링을 위해 message까지 return?
+// FIXME: 에러 핸들링을 위해 code, message까지 return? 리액트 쿼리 사용 때문에 고민
 export const createAuthCode = async (
   marketId: number,
 ): Promise<GenerateAuthCodeResponse | null> => {

--- a/src/apis/managers/client.ts
+++ b/src/apis/managers/client.ts
@@ -74,6 +74,7 @@ export const createManager = async (marketId: number): Promise<boolean> => {
   }
 };
 
+// FIXME: 에러 핸들링을 위해 message까지 return?
 export const createAuthCode = async (
   marketId: number,
 ): Promise<GenerateAuthCodeResponse | null> => {

--- a/src/apis/managers/model.ts
+++ b/src/apis/managers/model.ts
@@ -12,9 +12,15 @@ export type ReadCreatePendingMangerResponse = {
   ttl: number;
 };
 
+// FIXME: type issue
 export type GenerateAuthCodeResponse = {
-  authCode: string;
-  createdAt: string;
+  code: number;
+  message: string;
+  data: {
+    authCode: string;
+    marketName: string;
+    createdAt: string;
+  };
 };
 
 export type ValidationAuthCodeRequest = {

--- a/src/apis/managers/query.ts
+++ b/src/apis/managers/query.ts
@@ -53,27 +53,27 @@ export const useReadCreatePendingMangers = (marketId: number) => {
   });
 };
 
-export const useCreateManager = async (marketId: number) => {
+export const useCreateManager = (marketId: number) => {
   return useMutation({
     mutationKey: ['createManager', marketId],
     mutationFn: async () => {
       if (!marketId) return;
-      return createManager(marketId);
+      return await createManager(marketId);
     },
   });
 };
 
-export const useCreateAuthCode = async (marketId: number) => {
+export const useCreateAuthCode = (marketId: number) => {
   return useMutation({
     mutationKey: ['createAuthCode', marketId],
     mutationFn: async () => {
       if (!marketId) return;
-      return createAuthCode(marketId);
+      return await createAuthCode(marketId);
     },
   });
 };
 
-export const useValidateAuthCode = async ({
+export const useValidateAuthCode = ({
   marketName,
   authCode,
 }: ValidationAuthCodeRequest) => {
@@ -81,7 +81,7 @@ export const useValidateAuthCode = async ({
     mutationKey: ['validateAuthCode', authCode],
     mutationFn: async () => {
       if (!marketName || !authCode) return;
-      return valdiateAuthCode({marketName, authCode});
+      return await valdiateAuthCode({marketName, authCode});
     },
   });
 };

--- a/src/components/manager/ManagerList.tsx
+++ b/src/components/manager/ManagerList.tsx
@@ -4,7 +4,7 @@ import ManagerDeleteButton from './ManagerDeleteButton';
 
 type ManagerListProps = {
   memberId: number;
-  marketId: number | null;
+  marketId: number;
   name: string;
   marketRole: 'ROLE_STORE_OWNER' | 'ROLE_STORE_MANAGER';
 };
@@ -20,9 +20,6 @@ const ManagerList = ({
   name,
   marketRole,
 }: ManagerListProps) => {
-  if (!marketId) {
-    marketId = 0;
-  }
   const role = ROLE_LABELS[marketRole];
 
   return (

--- a/src/components/manager/ManagerLists.tsx
+++ b/src/components/manager/ManagerLists.tsx
@@ -7,7 +7,7 @@ import ManagerModal from './ManagerModal';
 
 type ManagerListsProps = {
   managers: ManagerInfo[] | null | undefined;
-  marketId: number | null;
+  marketId: number;
 };
 
 const ManagerLists = ({managers, marketId}: ManagerListsProps) => {

--- a/src/components/manager/ManagerLists.tsx
+++ b/src/components/manager/ManagerLists.tsx
@@ -33,7 +33,7 @@ const ManagerLists = ({managers, marketId}: ManagerListsProps) => {
           <ManagerList
             key={manager.id}
             memberId={manager.id}
-            marketId={marketId}
+            marketId={marketId!!}
             name={manager.name}
             marketRole={manager.marketRole}
           />

--- a/src/components/manager/ManagerLists.tsx
+++ b/src/components/manager/ManagerLists.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, {useState} from 'react';
 import S from './ManagerLists.style';
 import ManagerList from './ManagerList';
 import {ManagerInfo} from '@/types/Managers';
+import {BottomButton} from '../common';
+import ManagerModal from './ManagerModal';
 
 type ManagerListsProps = {
   managers: ManagerInfo[] | null | undefined;
@@ -9,24 +11,41 @@ type ManagerListsProps = {
 };
 
 const ManagerLists = ({managers, marketId}: ManagerListsProps) => {
-  return (
-    <S.ListsContainer>
-      <S.HeaderRow>
-        <S.HeaderText>이름</S.HeaderText>
-        <S.HeaderText>직책</S.HeaderText>
-        <S.HeaderText>삭제하기</S.HeaderText>
-      </S.HeaderRow>
+  const [visible, setVisible] = useState(false);
 
-      {managers?.map(manager => (
-        <ManagerList
-          key={manager.id}
-          memberId={manager.id}
-          marketId={marketId}
-          name={manager.name}
-          marketRole={manager.marketRole}
-        />
-      ))}
-    </S.ListsContainer>
+  const showModal = () => setVisible(true);
+  const hideModal = () => setVisible(false);
+
+  if (!marketId) {
+    marketId = 0;
+  }
+
+  return (
+    <>
+      <S.ListsContainer>
+        <S.HeaderRow>
+          <S.HeaderText>이름</S.HeaderText>
+          <S.HeaderText>직책</S.HeaderText>
+          <S.HeaderText>삭제하기</S.HeaderText>
+        </S.HeaderRow>
+
+        {managers?.map(manager => (
+          <ManagerList
+            key={manager.id}
+            memberId={manager.id}
+            marketId={marketId}
+            name={manager.name}
+            marketRole={manager.marketRole}
+          />
+        ))}
+        <BottomButton onPress={showModal}>직원 추가하기</BottomButton>
+      </S.ListsContainer>
+      <ManagerModal
+        visible={visible}
+        onDismiss={hideModal}
+        marketId={marketId}
+      />
+    </>
   );
 };
 

--- a/src/components/manager/ManagerLists.tsx
+++ b/src/components/manager/ManagerLists.tsx
@@ -16,10 +16,6 @@ const ManagerLists = ({managers, marketId}: ManagerListsProps) => {
   const showModal = () => setVisible(true);
   const hideModal = () => setVisible(false);
 
-  if (!marketId) {
-    marketId = 0;
-  }
-
   return (
     <>
       <S.ListsContainer>

--- a/src/components/manager/ManagerModal.style.tsx
+++ b/src/components/manager/ManagerModal.style.tsx
@@ -1,0 +1,98 @@
+import styled from '@emotion/native';
+
+const S = {
+  ModalContainer: styled.View`
+    display: flex;
+    flex-direction: column;
+    border-radius: 20px;
+    margin: 16px;
+    background-color: #ffffff;
+    padding: 8px;
+  `,
+
+  ModalHeader: styled.View`
+    display: flex;
+    flex-direction: row;
+
+    justify-content: center;
+    align-items: center;
+
+    height: 64px;
+
+    padding: 16px;
+
+    border-top-left-radius: 20px;
+    border-top-right-radius: 20px;
+
+    background-color: white;
+
+    box-sizing: border-box;
+  `,
+  ModalHeaderText: styled.Text`
+    font-weight: 700;
+    font-size: 16px;
+  `,
+  ModalFooter: styled.View`
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+  `,
+
+  ModalContentItem: styled.View`
+    display: flex;
+    flex-direction: row;
+
+    align-items: center;
+    justify-content: center;
+
+    gap: 8px;
+
+    padding: 8px;
+
+    background-color: white;
+  `,
+  ModalContentItemText: styled.Text`
+    font-size: 16px;
+    line-height: 20px;
+  `,
+  AuthCodeContainer: styled.View`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 8px;
+    background-color: #f9f9f9;
+    border-radius: 10px;
+    margin: 8px;
+  `,
+
+  MarketNameText: styled.Text`
+    font-size: 16px;
+    font-weight: 600;
+  `,
+
+  AuthCodeText: styled.Text`
+    font-size: 16px;
+    font-weight: 700;
+  `,
+
+  PendingManagerText: styled.Text`
+    font-size: 16px;
+    line-height: 20px;
+  `,
+
+  CountdownText: styled.Text`
+    font-size: 14px;
+    margin-top: 4px;
+    color: #555;
+  `,
+  FooterButtons: styled.View`
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    width: 100%;
+    padding: 8px;
+  `,
+};
+
+export default S;

--- a/src/components/manager/ManagerModal.style.tsx
+++ b/src/components/manager/ManagerModal.style.tsx
@@ -61,17 +61,19 @@ const S = {
     flex-direction: column;
     align-items: center;
     padding: 8px;
-    background-color: #f9f9f9;
+    background-color: white;
     border-radius: 10px;
     margin: 8px;
   `,
 
   MarketNameText: styled.Text`
+    line-height: 24px;
     font-size: 16px;
     font-weight: 600;
   `,
 
   AuthCodeText: styled.Text`
+    line-height: 24px;
     font-size: 16px;
     font-weight: 700;
   `,
@@ -84,7 +86,7 @@ const S = {
   CountdownText: styled.Text`
     font-size: 14px;
     margin-top: 4px;
-    color: #555;
+    color: red;
   `,
   FooterButtons: styled.View`
     display: flex;

--- a/src/components/manager/ManagerModal.tsx
+++ b/src/components/manager/ManagerModal.tsx
@@ -37,7 +37,7 @@ const ManagerModal = ({visible, onDismiss, marketId}: ManagerModalProps) => {
       setMarketName(res.data.marketName);
       setAuthCode(res.data.authCode);
       // 테스트 10초
-      const authTargetTime = Date.now() + 600000;
+      const authTargetTime = Date.now() + 10000;
       setExpireAuthTime(authTargetTime);
       setAuthTimerFlag(true);
     }
@@ -71,7 +71,7 @@ const ManagerModal = ({visible, onDismiss, marketId}: ManagerModalProps) => {
       handleTimerOff();
       queryClient.invalidateQueries({queryKey: ['pendingManagers', marketId]});
     }
-  }, [remainingTime]);
+  }, [remainingTime, authTimerFlag, marketId, queryClient]);
 
   return (
     <Portal>

--- a/src/components/manager/ManagerModal.tsx
+++ b/src/components/manager/ManagerModal.tsx
@@ -1,0 +1,103 @@
+import React, {useState, useEffect} from 'react';
+import {Portal, Modal} from 'react-native-paper';
+import S from './ManagerModal.style';
+import {useQueryClient} from '@tanstack/react-query';
+import {useCreateAuthCode, useReadCreatePendingMangers} from '@/apis/managers';
+import {BottomButton} from '../common';
+import {useIntervalValue} from '@/hooks/useIntervalValue';
+
+type ManagerModalProps = {
+  visible: boolean;
+  onDismiss: () => void;
+  marketId: number;
+};
+
+const ManagerModal = ({visible, onDismiss, marketId}: ManagerModalProps) => {
+  const queryClient = useQueryClient();
+
+  const [marketName, setMarketName] = useState<string | null>(null);
+  const [authCode, setAuthCode] = useState<string | null>(null);
+  const [expireAuthTime, setExpireAuthTime] = useState<number>(0);
+  const [authTimerFlag, setAuthTimerFlag] = useState<boolean>(false);
+
+  const {data: pendingManagerData} = useReadCreatePendingMangers(marketId);
+  const {mutateAsync: generateAuthCodeMutate} = useCreateAuthCode(marketId);
+
+  const handleGenerateAuthCode = async () => {
+    const res = await generateAuthCodeMutate();
+    if (res) {
+      queryClient.invalidateQueries({queryKey: ['pendingManagers', marketId]});
+      setMarketName(res.data.marketName);
+      setAuthCode(res.data.authCode);
+      // 테스트 10초
+      const targetTime = Date.now() + 5000;
+      setExpireAuthTime(targetTime);
+      setAuthTimerFlag(true);
+    }
+  };
+
+  const remainingTime = useIntervalValue(() => {
+    return Math.floor((expireAuthTime - Date.now()) / 1000);
+  }, 10);
+
+  useEffect(() => {
+    if (authTimerFlag && remainingTime <= 0) {
+      setMarketName(null);
+      setAuthCode(null);
+      queryClient.invalidateQueries({queryKey: ['pendingManagers', marketId]});
+      setAuthTimerFlag(false);
+    }
+  }, [remainingTime]);
+
+  return (
+    <Portal>
+      <Modal visible={visible} onDismiss={onDismiss}>
+        <S.ModalContainer>
+          <S.ModalHeader>
+            <S.ModalHeaderText>직원 등록</S.ModalHeaderText>
+          </S.ModalHeader>
+          {marketName && authCode && (
+            <S.ModalContentItem>
+              <S.AuthCodeContainer>
+                <S.MarketNameText>상호명: {marketName}</S.MarketNameText>
+                <S.AuthCodeText>인증코드: {authCode}</S.AuthCodeText>
+                {remainingTime > 0 && (
+                  <S.CountdownText>
+                    유효 시간: {remainingTime}초
+                  </S.CountdownText>
+                )}
+              </S.AuthCodeContainer>
+            </S.ModalContentItem>
+          )}
+          <S.ModalContentItem>
+            <BottomButton onPress={handleGenerateAuthCode}>
+              직원 인증 코드 생성하기
+            </BottomButton>
+          </S.ModalContentItem>
+
+          {pendingManagerData && (
+            <S.ModalContentItem>
+              <S.PendingManagerText>
+                등록 대기중인 직원: {pendingManagerData.memberName}
+              </S.PendingManagerText>
+            </S.ModalContentItem>
+          )}
+
+          <S.ModalFooter>
+            <S.FooterButtons>
+              <BottomButton onPress={onDismiss}>닫기</BottomButton>
+              <BottomButton
+                onPress={() => {
+                  /* 직원 등록하기 로직 추후 추가 */
+                }}>
+                직원 등록하기
+              </BottomButton>
+            </S.FooterButtons>
+          </S.ModalFooter>
+        </S.ModalContainer>
+      </Modal>
+    </Portal>
+  );
+};
+
+export default ManagerModal;

--- a/src/hooks/useInterval.ts
+++ b/src/hooks/useInterval.ts
@@ -1,0 +1,19 @@
+import {useEffect, useRef} from 'react';
+
+export function useInterval(callback: () => void, delay: number | null) {
+  const savedCallback = useRef(callback);
+
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    function tick() {
+      savedCallback.current();
+    }
+    if (delay !== null) {
+      let id = setInterval(tick, delay);
+      return () => clearInterval(id);
+    }
+  }, [delay]);
+}

--- a/src/hooks/useIntervalValue.ts
+++ b/src/hooks/useIntervalValue.ts
@@ -1,0 +1,17 @@
+import {useState, useEffect} from 'react';
+import {useInterval} from './useInterval';
+
+export function useIntervalValue<T>(
+  calculator: () => T,
+  delay: number,
+  deps: any[] = [],
+): T {
+  const [result, setResult] = useState<T>(calculator());
+
+  useInterval(() => {
+    const newResult = calculator();
+    if (newResult !== result) setResult(newResult);
+  }, delay);
+
+  return result;
+}

--- a/src/hooks/useIntervalValue.ts
+++ b/src/hooks/useIntervalValue.ts
@@ -1,11 +1,7 @@
-import {useState, useEffect} from 'react';
+import {useState} from 'react';
 import {useInterval} from './useInterval';
 
-export function useIntervalValue<T>(
-  calculator: () => T,
-  delay: number,
-  deps: any[] = [],
-): T {
+export function useIntervalValue<T>(calculator: () => T, delay: number): T {
   const [result, setResult] = useState<T>(calculator());
 
   useInterval(() => {

--- a/src/screens/MarketInfoScreen/index.tsx
+++ b/src/screens/MarketInfoScreen/index.tsx
@@ -137,7 +137,9 @@ const MarketInfoScreen = () => {
         </S.TimeContainer>
 
         <Label label={'직원 목록'} />
-        <ManagerLists managers={managersInfo} marketId={profile?.marketId} />
+        {profile?.marketId && (
+          <ManagerLists managers={managersInfo} marketId={profile?.marketId} />
+        )}
         {/* TODO: 대표 사진 선택 */}
         {/* <Label label={'대표 사진 선택'} required />
         <S.ImageCardGrid>


### PR DESCRIPTION
## #️⃣연관된 이슈

resolves: #90
 
<!-- resolves: #이슈번호, #이슈번호 -->

## 📝작업 내용

사장님 입장 직원 등록 로직
- 직원 등록 모달 생성
- 타이머 사용 -> useInterval, useIntervalValue 훅 사용 [참조1](https://class.codejong.kr/t/react/371/3) [참조2
](https://overreacted.io/making-setinterval-declarative-with-react-hooks/)- 인증 코드 생성
- 인증 대기 직원 확인
- 직원 등록

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷 (선택)

https://github.com/user-attachments/assets/6ccbf7c8-e607-4b93-b128-7e05c0a1e137

현재 등록 대기중인 직원 조회 로직이 미완성입니다.
등록 대기중 직원이 생성되면 백엔드에서 사장님한테 fcm 알림 전송을 해준다고 하는데,
차후 fcm 만질 때 해당 알림 잡아서 쿼리키 갱신하도록 하겠습니다.
현재는 임의로 useEffect 내부에 넣었습니다.

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

1. 타이머 관련 로직
로직 수정했습니다! 3/5 오후 기준 영상입니다. 최적화가 필요합니다..
![Simulator Screen Recording - iPhone 15 Pro - 2025-03-05 at 13 45 43](https://github.com/user-attachments/assets/b4b94eb5-4c01-4767-af5f-fc266844047f)



2. GenerateAuthCodeResponse
api에서 받은 response.data 만 리턴을 할 지, 지금처럼 전체를 리턴할 지 고민이었습니다.
리액트 쿼리 사용하고 있기 때문에 전체 리턴해서 차후 쿼리 단에서 혹은 페이지 단에서 에러 핸들링 하는 것이 맞다고 생각해 진행했는데
리뷰 부탁드립니다. 

3. marketId 타입 질문
타입 가드를 어디서 해서 내려야할 지 궁금합니다.
페이지단에서 일괄적으로 하는 것이 맞나..

항상 감사합니다..!