### PR TITLE
feat: 주문 내역 react-query 마이그레이션

### DIFF
--- a/ios/AdminClientApp.xcodeproj/project.pbxproj
+++ b/ios/AdminClientApp.xcodeproj/project.pbxproj
@@ -510,7 +510,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 0.0.3;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -539,7 +539,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 0.0.3;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -638,10 +638,7 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -726,10 +723,7 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/src/apis/fcm.ts
+++ b/src/apis/fcm.ts
@@ -6,8 +6,7 @@ export const registerFCMToken = async (
   console.log('Register FCM Token:', deviceToken);
   try {
     const res = await apiClient.post<{code: number; message: string}>(
-      'common/members/device-token',
-      {deviceToken},
+      `common/members/device-token?deviceToken=${deviceToken}`,
     );
     return !!res && res.code === 200;
   } catch (error) {

--- a/src/apis/orders/client.ts
+++ b/src/apis/orders/client.ts
@@ -1,0 +1,51 @@
+import apiClient from '../ApiClient';
+import {OrdersRequest, OrdersResponse, OrderPatchRequest} from './model';
+
+/**
+ * @description 주문 상태에 따른 주문 목록을 가져옵니다.
+ */
+export const getPendingOrderLists = async ({
+  marketId,
+  ordersStatus,
+}: OrdersRequest): Promise<OrdersResponse | null> => {
+  try {
+    const res = await apiClient.get<OrdersResponse>('owner/markets/orders', {
+      params: {
+        ordersStatus,
+        marketId,
+      },
+    });
+
+    if (res) {
+      return res;
+    } else {
+      console.log('응답 데이터가 없습니다.');
+      return null;
+    }
+  } catch (error) {
+    console.error('Error fetching pending orders data:', error);
+    return null;
+  }
+};
+
+export const updateOrderStatus = async ({
+  ordersId,
+  ordersStatus,
+}: OrderPatchRequest): Promise<boolean> => {
+  try {
+    const res = await apiClient.patch<{code: number}>(
+      'owner/orders',
+      {},
+      {
+        params: {
+          ordersId,
+          ordersStatus,
+        },
+      },
+    );
+    return !!res && res.code === 200;
+  } catch (error) {
+    console.error(error);
+    return false;
+  }
+};

--- a/src/apis/orders/index.ts
+++ b/src/apis/orders/index.ts
@@ -1,0 +1,2 @@
+export * from './query';
+export * from './model';

--- a/src/apis/orders/model.ts
+++ b/src/apis/orders/model.ts
@@ -1,0 +1,13 @@
+import {OrderDetailInfoType, OrdersStatus} from '@/types/OrderDetailType';
+
+export type OrdersRequest = {
+  ordersStatus: OrdersStatus;
+  marketId: number;
+};
+
+export type OrderPatchRequest = {
+  ordersId: string;
+  ordersStatus: OrdersStatus;
+};
+
+export type OrdersResponse = OrderDetailInfoType[];

--- a/src/apis/orders/query.ts
+++ b/src/apis/orders/query.ts
@@ -1,0 +1,22 @@
+import {useQuery, useMutation} from '@tanstack/react-query';
+import {OrdersRequest, OrderPatchRequest} from './model';
+import {getPendingOrderLists, updateOrderStatus} from './client';
+
+export const useGetOrders = ({ordersStatus, marketId}: OrdersRequest) => {
+  return useQuery({
+    queryKey: ['orders', ordersStatus, marketId],
+    queryFn: () => {
+      if (!marketId) return null;
+      return getPendingOrderLists({ordersStatus, marketId});
+    },
+    enabled: marketId !== 0,
+  });
+};
+
+export const usePatchOrder = () => {
+  return useMutation({
+    mutationKey: ['patchOrder'],
+    mutationFn: ({ordersId, ordersStatus}: OrderPatchRequest) =>
+      updateOrderStatus({ordersId, ordersStatus}),
+  });
+};

--- a/src/apis/orders/query.ts
+++ b/src/apis/orders/query.ts
@@ -1,4 +1,4 @@
-import {useQuery, useMutation} from '@tanstack/react-query';
+import {useQuery, useMutation, keepPreviousData} from '@tanstack/react-query';
 import {OrdersRequest, OrderPatchRequest} from './model';
 import {getPendingOrderLists, updateOrderStatus} from './client';
 
@@ -10,6 +10,8 @@ export const useGetOrders = ({ordersStatus, marketId}: OrdersRequest) => {
       return getPendingOrderLists({ordersStatus, marketId});
     },
     enabled: marketId !== 0,
+    staleTime: 1000 * 60 * 5,
+    placeholderData: keepPreviousData,
   });
 };
 

--- a/src/components/pendingOrder/PendingOrders.tsx
+++ b/src/components/pendingOrder/PendingOrders.tsx
@@ -7,11 +7,10 @@ import {useQueryClient} from '@tanstack/react-query';
 import {ActivityIndicator} from 'react-native-paper';
 
 type PendingOrdersProps = {
-  marketId: number;
   orders: OrderDetailInfoType[];
 };
 
-const PendingOrders = ({orders, marketId}: PendingOrdersProps) => {
+const PendingOrders = ({orders}: PendingOrdersProps) => {
   const queryClient = useQueryClient();
   const {mutate: patchOrderMutate, isPending: isPatchOrderPending} =
     usePatchOrder();

--- a/src/components/pendingOrder/PendingOrders.tsx
+++ b/src/components/pendingOrder/PendingOrders.tsx
@@ -18,7 +18,7 @@ const PendingOrders = ({orders, marketId}: PendingOrdersProps) => {
 
   const isLoading = isPatchOrderPending;
   if (isLoading || !orders) {
-    return <ActivityIndicator />;
+    <ActivityIndicator />;
   }
 
   const handleStatusChange = (orderId: string, newStatus: OrdersStatus) => {
@@ -27,7 +27,7 @@ const PendingOrders = ({orders, marketId}: PendingOrdersProps) => {
       {
         onSuccess: () => {
           queryClient.invalidateQueries({
-            queryKey: ['orders', newStatus, marketId],
+            queryKey: ['orders'],
           });
         },
         onError: error => {

--- a/src/hooks/usePullDownRefresh.ts
+++ b/src/hooks/usePullDownRefresh.ts
@@ -1,6 +1,6 @@
 import {useCallback, useState} from 'react';
 
-const usePullDownRefresh = (callback: () => Promise<void>) => {
+const usePullDownRefresh = <T>(callback: () => Promise<T>) => {
   const [refreshing, setRefreshing] = useState(false);
 
   const onRefresh = useCallback(async () => {

--- a/src/screens/OrderHistoryScreen/PendingOrders.tsx
+++ b/src/screens/OrderHistoryScreen/PendingOrders.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useState} from 'react';
+import React from 'react';
 import {View} from 'react-native';
 import PendingOrder from '@/components/pendingOrder/PendingOrder';
 import {OrderDetailInfoType, OrdersStatus} from '@/types/OrderDetailType';

--- a/src/screens/OrderHistoryScreen/index.tsx
+++ b/src/screens/OrderHistoryScreen/index.tsx
@@ -7,7 +7,7 @@ import {ToggleButton} from '@/components/common';
 import EmptyMarket from '@/components/common/EmptyMarket';
 import NonRegister from '@/components/common/NonRegister';
 import useProfile from '@/hooks/useProfile';
-import {useGetOrders, usePatchOrder} from '@/apis/orders/query';
+import {useGetOrders} from '@/apis/orders/query';
 import usePullDownRefresh from '@/hooks/usePullDownRefresh';
 import PendingOrdersScreen from './PendingOrders';
 import {RefreshControl} from 'react-native';

--- a/src/screens/OrderHistoryScreen/index.tsx
+++ b/src/screens/OrderHistoryScreen/index.tsx
@@ -9,7 +9,7 @@ import NonRegister from '@/components/common/NonRegister';
 import useProfile from '@/hooks/useProfile';
 import {useGetOrders} from '@/apis/orders/query';
 import usePullDownRefresh from '@/hooks/usePullDownRefresh';
-import PendingOrdersScreen from './PendingOrders';
+import PendingOrdersScreen from '../../components/pendingOrder/PendingOrders';
 import {RefreshControl} from 'react-native';
 import {ActivityIndicator} from 'react-native-paper';
 

--- a/src/screens/OrderHistoryScreen/index.tsx
+++ b/src/screens/OrderHistoryScreen/index.tsx
@@ -60,7 +60,7 @@ const OrderHistoryScreen = () => {
         refreshControl={
           <RefreshControl onRefresh={onRefresh} refreshing={refreshing} />
         }>
-        <PendingOrdersScreen orders={orders} marketId={marketId} />
+        <PendingOrdersScreen orders={orders} />
       </S.PendingOrderScreenContainer>
     </View>
   );

--- a/src/screens/ReviewReplyScreen/index.tsx
+++ b/src/screens/ReviewReplyScreen/index.tsx
@@ -40,7 +40,7 @@ const ReviewReplyScreen = ({route}: ReviewReplyScreenProps) => {
       <S.InfoText>
         작성일: {new Date(reviewData.createdAt).toLocaleDateString()}
       </S.InfoText>
-      <S.InfoText>제품: {reviewData.products.join(', ')}</S.InfoText>
+      <S.InfoText>메뉴: {reviewData.products.join(', ')}</S.InfoText>
 
       {reviewData.imageUrls && reviewData.imageUrls.length > 0 && (
         <S.ImageContainer>

--- a/src/types/OrderDetailType.ts
+++ b/src/types/OrderDetailType.ts
@@ -22,3 +22,11 @@ export type OrderDetailResponseType = {
   message: string;
   data: OrderDetailInfoType;
 };
+
+export type OrdersStatus =
+  | 'ORDERED'
+  | 'ACCEPTED'
+  | 'PICKEDUP_OR_CANCELED'
+  | 'PICKEDUP'
+  | 'NO_SHOW'
+  | 'CANCELED';


### PR DESCRIPTION

## 📝작업 내용
- 주문 내역 페이지 리액트쿼리 마이그레이션
- device token query string으로 fetch 로직 변경

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->


### 스크린샷 (선택)

![Simulator Screen Recording - iPhone 15 Pro - 2025-03-06 at 00 41 57](https://github.com/user-attachments/assets/578ff14e-c8cc-446b-9db5-9299fdc22c45)

얼리 리턴으로 로딩 유지했습니다. 쿼리 이것저것 만져봤는데.. 쉽지 않네요
얼리 리턴하지 않고 조건부 렌더링으로 걸면 PendingOrders.tsx 내 orders.slice()에서 빈배열로 인해 터져버려서
회의 때 보여드린대로 유지했습니다.

예약접수, 픽업대기, 완료/취소 간 useGetOrders 내 staleTime으로 5분 캐시 유지합니다.


## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
