### PR TITLE
feat: 직원 인증 코드 입력 로직

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -25,17 +25,9 @@ function App(): React.JSX.Element {
 
   return (
     <RootProvider>
-      <SafeAreaView style={styles.container}>
-        <AppNavigator />
-      </SafeAreaView>
+      <AppNavigator />
     </RootProvider>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-});
 
 export default App;

--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,4 @@
 import React, {useEffect} from 'react';
-import {StyleSheet} from 'react-native';
-import {SafeAreaView} from 'react-native-safe-area-context';
 import SplashScreen from 'react-native-splash-screen';
 
 import './gesture-handler';

--- a/src/apis/CustomError.ts
+++ b/src/apis/CustomError.ts
@@ -1,0 +1,18 @@
+type CustomErrorType<T = unknown> = T extends Error ? T : unknown;
+
+class CustomError<T = unknown> extends Error {
+  errorCode?: number;
+  errorMessage?: string;
+
+  constructor(args: CustomErrorType<T>) {
+    if (args instanceof Error) {
+      super(args.message);
+    } else {
+      super('Unknown error');
+      this.errorMessage = 'Unknown error';
+    }
+    Object.assign(this, args);
+  }
+}
+
+export default CustomError;

--- a/src/apis/managers/client.ts
+++ b/src/apis/managers/client.ts
@@ -6,6 +6,7 @@ import {
   ReadManagersResponse,
   ValidationAuthCodeRequest,
 } from './model';
+import CustomError from '../CustomError';
 
 export const withDrawManager = async (marketId: number): Promise<boolean> => {
   try {
@@ -15,7 +16,7 @@ export const withDrawManager = async (marketId: number): Promise<boolean> => {
     return !!res && res.code === 200;
   } catch (error) {
     console.log('직원 탈퇴 에러', error);
-    return false;
+    throw new CustomError(error);
   }
 };
 
@@ -30,7 +31,7 @@ export const deleteManager = async ({
     return !!res && res.code === 200;
   } catch (error) {
     console.log('직원 해고 에러', error);
-    return false;
+    throw new CustomError(error);
   }
 };
 
@@ -44,7 +45,7 @@ export const readManagers = async (
     return res;
   } catch (error) {
     console.error('직원 조회 에러', error);
-    return null;
+    throw new CustomError(error);
   }
 };
 
@@ -58,7 +59,7 @@ export const readCreatePendingManagers = async (
     return res;
   } catch (error) {
     console.error('인증 대기 직원 조회 에러');
-    return null;
+    throw new CustomError(error);
   }
 };
 
@@ -70,7 +71,7 @@ export const createManager = async (marketId: number): Promise<boolean> => {
     return !!res && res.code === 200;
   } catch (error) {
     console.error('직원 생성 에러', error);
-    return false;
+    throw new CustomError(error);
   }
 };
 
@@ -85,7 +86,7 @@ export const createAuthCode = async (
     return res;
   } catch (error) {
     console.error('인증 코드 생성 에러');
-    return null;
+    throw new CustomError(error);
   }
 };
 
@@ -103,7 +104,7 @@ export const valdiateAuthCode = async ({
     );
     return !!res && res.code === 200;
   } catch (error) {
-    console.error('직원 인증 코드 에러');
-    return false;
+    console.error('직원 인증 코드 에러', error);
+    throw new CustomError(error);
   }
 };

--- a/src/apis/managers/query.ts
+++ b/src/apis/managers/query.ts
@@ -73,15 +73,11 @@ export const useCreateAuthCode = (marketId: number) => {
   });
 };
 
-export const useValidateAuthCode = ({
-  marketName,
-  authCode,
-}: ValidationAuthCodeRequest) => {
+export const useValidateAuthCode = () => {
   return useMutation({
-    mutationKey: ['validateAuthCode', authCode],
-    mutationFn: async () => {
-      if (!marketName || !authCode) return;
-      return await valdiateAuthCode({marketName, authCode});
+    mutationKey: ['validateAuthCode'],
+    mutationFn: ({marketName, authCode}: ValidationAuthCodeRequest) => {
+      return valdiateAuthCode({marketName, authCode});
     },
   });
 };

--- a/src/apis/markets/query.ts
+++ b/src/apis/markets/query.ts
@@ -23,7 +23,7 @@ export const useMarketList = () => {
   });
 };
 
-export const useMarket = (marketId: number | undefined | null) => {
+export const useGetMarket = (marketId: number | undefined | null) => {
   return useQuery({
     queryKey: ['market', marketId],
     queryFn: () => {

--- a/src/components/manager/ManagerDeleteButton.tsx
+++ b/src/components/manager/ManagerDeleteButton.tsx
@@ -42,7 +42,7 @@ const ManagerDeleteButton = ({
         <Modal visible={visible} onDismiss={hideModal}>
           <S.ModalContainer>
             <S.ModalHeader>
-              <S.ModalHeaderText>해고하시겠습니까?</S.ModalHeaderText>
+              <S.ModalHeaderText>직원을 삭제하시겠습니까?</S.ModalHeaderText>
             </S.ModalHeader>
             <S.ModalFooter>
               <Button onPress={handleDeletePress}>확인</Button>

--- a/src/components/manager/ManagerList.tsx
+++ b/src/components/manager/ManagerList.tsx
@@ -7,6 +7,7 @@ type ManagerListProps = {
   marketId: number;
   name: string;
   marketRole: 'ROLE_STORE_OWNER' | 'ROLE_STORE_MANAGER';
+  isEditPermssion: boolean;
 };
 
 const ROLE_LABELS: Record<'ROLE_STORE_OWNER' | 'ROLE_STORE_MANAGER', string> = {
@@ -19,6 +20,7 @@ const ManagerList = ({
   memberId,
   name,
   marketRole,
+  isEditPermssion,
 }: ManagerListProps) => {
   const role = ROLE_LABELS[marketRole];
 
@@ -26,7 +28,7 @@ const ManagerList = ({
     <S.ListContainer>
       <S.NameText>{name}</S.NameText>
       <S.RoleText>{role}</S.RoleText>
-      {role === '직원' ? (
+      {!isEditPermssion && role === '직원' ? (
         <ManagerDeleteButton marketId={marketId} memberId={memberId} />
       ) : (
         <S.EmptyPlaceholder />

--- a/src/components/manager/ManagerLists.tsx
+++ b/src/components/manager/ManagerLists.tsx
@@ -8,9 +8,14 @@ import ManagerModal from './ManagerModal';
 type ManagerListsProps = {
   managers: ManagerInfo[] | null | undefined;
   marketId: number;
+  isEditPermssion: boolean;
 };
 
-const ManagerLists = ({managers, marketId}: ManagerListsProps) => {
+const ManagerLists = ({
+  managers,
+  marketId,
+  isEditPermssion,
+}: ManagerListsProps) => {
   const [visible, setVisible] = useState(false);
 
   const showModal = () => setVisible(true);
@@ -32,9 +37,12 @@ const ManagerLists = ({managers, marketId}: ManagerListsProps) => {
             marketId={marketId!!}
             name={manager.name}
             marketRole={manager.marketRole}
+            isEditPermssion={isEditPermssion}
           />
         ))}
-        <BottomButton onPress={showModal}>직원 추가하기</BottomButton>
+        <BottomButton onPress={showModal} disabled={isEditPermssion}>
+          직원 추가하기
+        </BottomButton>
       </S.ListsContainer>
       <ManagerModal
         visible={visible}

--- a/src/hooks/useMarket.ts
+++ b/src/hooks/useMarket.ts
@@ -9,8 +9,10 @@ import useProfile from './useProfile';
 
 type MarketStore = {
   loading: boolean;
-  market: Pick<MarketType, 'id' | 'name'>[];
-  getMemberMarkets: () => Promise<Pick<MarketType, 'id' | 'name'>[] | null>;
+  market: Array<Pick<MarketType, 'id' | 'name'> & {role: string}> | null;
+  getMemberMarkets: () => Promise<Array<
+    Pick<MarketType, 'id' | 'name'> & {role: string}
+  > | null>;
   marketInfo: MarketType | null;
   setMarketInfo: (marketInfo: MarketType) => void;
 };
@@ -28,10 +30,13 @@ const useMarketStore = create<MarketStore>(set => ({
       set({loading: false});
       return null;
     }
-    const ret = marketRes.map(({marketId: id, marketName: name}) => ({
-      id,
-      name,
-    }));
+    const ret = marketRes.map(
+      ({marketId: id, marketName: name, marketRole: role}) => ({
+        id,
+        name,
+        role,
+      }),
+    );
 
     set({market: ret, loading: false});
 
@@ -58,7 +63,7 @@ const useMarket = () => {
     if (!res || !res.length) {
       return;
     }
-
+    console.log('marketMember: ', res);
     if (!profile.marketId) {
       selectMarket(res[0].id);
     }
@@ -72,9 +77,9 @@ const useMarket = () => {
     if (!profile || !profile?.marketId) {
       return;
     }
-
     const res = await getMarketAPI(profile.marketId);
 
+    console.log('market: ', res);
     if (!res) {
       return;
     }

--- a/src/hooks/useMarket.ts
+++ b/src/hooks/useMarket.ts
@@ -63,7 +63,6 @@ const useMarket = () => {
     if (!res || !res.length) {
       return;
     }
-    console.log('marketMember: ', res);
     if (!profile.marketId) {
       selectMarket(res[0].id);
     }
@@ -79,7 +78,6 @@ const useMarket = () => {
     }
     const res = await getMarketAPI(profile.marketId);
 
-    console.log('market: ', res);
     if (!res) {
       return;
     }

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -15,6 +15,7 @@ import {registerFCMToken} from '@/apis/fcm';
 
 type AdminUserType = UserType & {
   marketId: number | null;
+  role: string | null;
 };
 
 type ProfileStore = {

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -36,7 +36,7 @@ const useProfileStore = create<ProfileStore>(set => ({
       set({profile: null, loading: false});
       return;
     }
-    set({profile: {...profileRes, marketId: null}, loading: false});
+    set({profile: {...profileRes, marketId: null, role: null}, loading: false});
   },
   setCurrentMarketId: marketId => {
     set(state => {

--- a/src/navigation/RegisterMarketNavigator.tsx
+++ b/src/navigation/RegisterMarketNavigator.tsx
@@ -5,17 +5,21 @@ import {
 } from '@react-navigation/stack';
 
 import RegisterMarketScreen from '@/screens/RegisterMarketScreen';
+import RegisterManagerScreen from '@/screens/RegisterManagerScreen';
 
 import {defaultOptions} from '@/components/common/Appbar/AppbarOptions';
 import HeaderTitle from '@/components/common/Appbar/HeaderTitle';
 
 import {RootStackParamList} from '@/types/StackNavigationType';
-
 const Stack = createStackNavigator<RootStackParamList>();
 
 const registerMarketScreenOptions: StackNavigationOptions = {
   ...defaultOptions,
   headerTitle: () => <HeaderTitle title="매장 등록" />,
+};
+const registerManagerScreenOptions: StackNavigationOptions = {
+  ...defaultOptions,
+  headerTitle: () => <HeaderTitle title="직원 인증" />,
 };
 
 const ResgitrationMarketNavigator = () => {
@@ -25,6 +29,11 @@ const ResgitrationMarketNavigator = () => {
         name="RegisterMarket"
         component={RegisterMarketScreen}
         options={registerMarketScreenOptions}
+      />
+      <Stack.Screen
+        name="RegisterManager"
+        component={RegisterManagerScreen}
+        options={registerManagerScreenOptions}
       />
     </Stack.Navigator>
   );

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -5,14 +5,14 @@ import HomeNavigator from './HomeNavigator';
 import ResgitrationMarketNavigator from './RegisterMarketNavigator';
 import RegistrationNavigaitor from './RegisterNavigator';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
-import {View} from 'react-native';
+import {View, StyleSheet} from 'react-native';
 
 const Stack = createStackNavigator<RootStackParamList>();
 
 const AppNavigator = () => {
   const inset = useSafeAreaInsets();
   return (
-    <View style={{paddingBottom: inset.bottom, flex: 1}}>
+    <View style={[styles.container, {paddingBottom: inset.bottom}]}>
       <Stack.Navigator
         initialRouteName={'Home'}
         screenOptions={{headerShown: false}}>
@@ -27,5 +27,11 @@ const AppNavigator = () => {
     </View>
   );
 };
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});
 
 export default AppNavigator;

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -4,22 +4,27 @@ import React from 'react';
 import HomeNavigator from './HomeNavigator';
 import ResgitrationMarketNavigator from './RegisterMarketNavigator';
 import RegistrationNavigaitor from './RegisterNavigator';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
+import {View} from 'react-native';
 
 const Stack = createStackNavigator<RootStackParamList>();
 
 const AppNavigator = () => {
+  const inset = useSafeAreaInsets();
   return (
-    <Stack.Navigator
-      initialRouteName={'Home'}
-      screenOptions={{headerShown: false}}>
-      <Stack.Screen name="Home" component={HomeNavigator} />
-      <Stack.Screen
-        name="RegisterMarketRoot"
-        component={ResgitrationMarketNavigator}
-      />
-      <Stack.Screen name="Register" component={RegistrationNavigaitor} />
-      {/* Add more screens here */}
-    </Stack.Navigator>
+    <View style={{paddingBottom: inset.bottom, flex: 1}}>
+      <Stack.Navigator
+        initialRouteName={'Home'}
+        screenOptions={{headerShown: false}}>
+        <Stack.Screen name="Home" component={HomeNavigator} />
+        <Stack.Screen
+          name="RegisterMarketRoot"
+          component={ResgitrationMarketNavigator}
+        />
+        <Stack.Screen name="Register" component={RegistrationNavigaitor} />
+        {/* Add more screens here */}
+      </Stack.Navigator>
+    </View>
   );
 };
 

--- a/src/screens/MarketInfoScreen/index.tsx
+++ b/src/screens/MarketInfoScreen/index.tsx
@@ -1,6 +1,6 @@
 import {useNavigation} from '@react-navigation/native';
 import {StackNavigationProp} from '@react-navigation/stack';
-import React, {useEffect, useState, useMemo} from 'react';
+import React, {useEffect, useState} from 'react';
 import {Alert} from 'react-native';
 import DatePicker from 'react-native-date-picker';
 import {RefreshControl} from 'react-native-gesture-handler';
@@ -21,7 +21,6 @@ import {useQueryClient} from '@tanstack/react-query';
 import S from './MarketInfoScreen.style';
 import {useReadManagers} from '@/apis/managers';
 import ManagerLists from '@/components/manager/ManagerLists';
-import useMarket from '@/hooks/useMarket';
 
 const timeOptions = {
   'market-open': '영업 시작 시간',
@@ -32,7 +31,6 @@ const timeOptions = {
 
 const MarketInfoScreen = () => {
   const {profile} = useProfile();
-  // const {market: a, marketInfo: b} = useMarket();
   const queryClient = useQueryClient();
   const {data: marketInfo} = useGetMarket(profile?.marketId);
   const {data: managersInfo} = useReadManagers(profile?.marketId);
@@ -98,7 +96,6 @@ const MarketInfoScreen = () => {
         refreshControl={
           <RefreshControl onRefresh={onRefresh} refreshing={refreshing} />
         }>
-        {/* <Text>{currentMarketRole}</Text> */}
         <TextInput label={'상호명'} placeholder={marketInfo?.name} disabled />
         <TextInput
           label={'한 줄 소개'}

--- a/src/screens/MenuManageScreen/MenuManageDetailScreen.tsx
+++ b/src/screens/MenuManageScreen/MenuManageDetailScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import {Alert} from 'react-native';
 import {RefreshControl, ScrollView} from 'react-native-gesture-handler';
 

--- a/src/screens/MenuManageScreen/MenuManageDetailScreen.tsx
+++ b/src/screens/MenuManageScreen/MenuManageDetailScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from 'react';
+import React, {useState} from 'react';
 import {Alert} from 'react-native';
 import {RefreshControl, ScrollView} from 'react-native-gesture-handler';
 

--- a/src/screens/MenuManageScreen/index.tsx
+++ b/src/screens/MenuManageScreen/index.tsx
@@ -5,7 +5,7 @@ import MenuManageDetailScreen from './MenuManageDetailScreen';
 
 import EmptyMarket from '@/components/common/EmptyMarket';
 import NonRegister from '@/components/common/NonRegister';
-import {useMarket} from '@/apis/markets';
+import {useGetMarket} from '@/apis/markets';
 import useProduct from '@/hooks/useProduct';
 import useProfile from '@/hooks/useProfile';
 import {MenuType} from '@/types/ProductType';
@@ -14,7 +14,7 @@ import {useIsFocused} from '@react-navigation/native';
 const MenuManageScreen = () => {
   const {profile} = useProfile();
   const {products, fetch: fetchProduct} = useProduct();
-  const {data: marketInfo} = useMarket(profile?.marketId);
+  const {data: marketInfo} = useGetMarket(profile?.marketId);
 
   const [menus, setMenus] = useState<MenuType[]>([]);
   const isFocused = useIsFocused();

--- a/src/screens/MyPageScreen/MyPageScreen.style.tsx
+++ b/src/screens/MyPageScreen/MyPageScreen.style.tsx
@@ -99,6 +99,7 @@ const S = {
     flex-direction: column;
 
     gap: 8px;
+
     padding: 16px;
   `,
 
@@ -139,7 +140,7 @@ const S = {
     gap: 8px;
 
     padding: 16px;
-    margin: 16px 0;
+    margin: 8px 0;
 
     border-radius: 8px;
 

--- a/src/screens/MyPageScreen/index.tsx
+++ b/src/screens/MyPageScreen/index.tsx
@@ -30,6 +30,7 @@ import {
 } from '@/utils/notification';
 
 import S from './MyPageScreen.style';
+import useMarket from '@/hooks/useMarket';
 
 // TODO: 강제 fetch 방법 강구
 
@@ -40,6 +41,7 @@ const MyPageScreen = () => {
   const queryClient = useQueryClient();
 
   const {profile, fetch: fetchProfile, selectMarket, logout} = useProfile();
+  const {fetchMarket, fetch: fetchMemberMarkets} = useMarket();
   const {data: marketListData, isLoading} = useMarketList();
 
   const marketList =
@@ -185,8 +187,9 @@ const MyPageScreen = () => {
                     onPress={() => {
                       if (profile?.marketId !== id) {
                         selectMarket(id);
+                        fetchMarket();
+                        fetchMemberMarkets();
                       }
-
                       setOpenModal(false);
                     }}>
                     {/* <S.ModalContentItemIcon

--- a/src/screens/MyPageScreen/index.tsx
+++ b/src/screens/MyPageScreen/index.tsx
@@ -208,6 +208,16 @@ const MyPageScreen = () => {
                   <Icon name="plus" size={20} color="#000000" />
                   <S.ModalAddButtonText>매장 추가</S.ModalAddButtonText>
                 </S.ModalAddButton>
+                <S.ModalAddButton
+                  onPress={() => {
+                    navigation.navigate('RegisterMarketRoot', {
+                      screen: 'RegisterManager',
+                    });
+                    setOpenModal(false);
+                  }}>
+                  <Icon name="plus" size={20} color="#000000" />
+                  <S.ModalAddButtonText>직원 인증</S.ModalAddButtonText>
+                </S.ModalAddButton>
               </S.ModalContent>
             </S.ModalContainer>
           </Modal>

--- a/src/screens/OrderHistoryScreen/index.tsx
+++ b/src/screens/OrderHistoryScreen/index.tsx
@@ -1,7 +1,7 @@
 import React, {useState} from 'react';
 import {View} from 'react-native';
 
-import {useMarket} from '@/apis/markets';
+import {useGetMarket} from '@/apis/markets';
 
 import {ToggleButton} from '@/components/common';
 import EmptyMarket from '@/components/common/EmptyMarket';
@@ -21,7 +21,7 @@ const OrderHistoryScreen = () => {
   const {profile} = useProfile();
   const marketId = profile?.marketId;
 
-  const {data: marketInfo} = useMarket(marketId);
+  const {data: marketInfo} = useGetMarket(marketId);
   const {
     data: orders,
     refetch,

--- a/src/screens/RegisterManagerScreen/RegisterManagerScreen.style.tsx
+++ b/src/screens/RegisterManagerScreen/RegisterManagerScreen.style.tsx
@@ -1,0 +1,43 @@
+import styled from '@emotion/native';
+import {Button, Text} from 'react-native-paper';
+
+const S = {
+  RegisterManagerContainer: styled.View`
+    position: relative;
+    flex: 1;
+    padding: 16px;
+    gap: 20px;
+  `,
+
+  RegisterManagerInputContainer: styled.View`
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+  `,
+
+  ConfirmLayout: styled.View`
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 8px;
+  `,
+  ConfirmButton: styled(Button)<{disabled?: boolean}>`
+    background-color: ${props => {
+      if (props.disabled) {
+        return props.theme.colors.primaryDisabled;
+      }
+      return props.theme.colors.primary;
+    }};
+    border-radius: 8px;
+  `,
+  ConfirmButtonText: styled(Text)<{disabled?: boolean}>`
+    color: ${props => {
+      if (props.disabled) {
+        return props.theme.colors.tertiaryDisabled;
+      }
+      return props.theme.colors.tertiary;
+    }};
+  `,
+};
+
+export default S;

--- a/src/screens/RegisterManagerScreen/index.tsx
+++ b/src/screens/RegisterManagerScreen/index.tsx
@@ -1,0 +1,103 @@
+import {useNavigation} from '@react-navigation/native';
+import React, {useState} from 'react';
+import S from './RegisterManagerScreen.style';
+import TextInput from '@/components/common/TextInput/TextInput';
+import {useValidateAuthCode} from '@/apis/managers';
+import useMarket from '@/hooks/useMarket';
+import {StackNavigationProp} from '@react-navigation/stack';
+import {RootStackParamList} from '@/types/StackNavigationType';
+import {Alert} from 'react-native';
+
+const isError = (value: string | undefined, validLength?: number) => {
+  if (value === undefined) {
+    return false;
+  }
+
+  if (value.length === 0) {
+    return true;
+  }
+
+  return !!validLength && value?.length !== validLength;
+};
+
+const RegisterManagerScreen = () => {
+  const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
+
+  const [marketName, setMarketName] = useState<string | undefined>(undefined);
+  const [authCode, setAuthCode] = useState<string | undefined>(undefined);
+
+  const {refresh} = useMarket();
+
+  const {mutate: validateAuthCodeMutate} = useValidateAuthCode();
+
+  const handleValidtateAuthCode = () => {
+    if (!marketName || !authCode) {
+      Alert.alert('잘못된 입력입니다.');
+      return;
+    }
+    validateAuthCodeMutate(
+      {marketName, authCode},
+      {
+        onSuccess: async () => {
+          // TODO: fcm 작업 이후 사장 승인 이후 감지
+          // selectMarket(data);
+          await refresh();
+          Alert.alert('사장님이 승인하시면 직원으로 등록돼요!');
+          navigation.goBack();
+        },
+        onError: error => {
+          const errorMessage =
+            (error as any)?.errorMessage || '알 수 없는 에러입니다.';
+          Alert.alert(errorMessage);
+        },
+      },
+    );
+  };
+
+  return (
+    <S.RegisterManagerContainer>
+      <S.RegisterManagerInputContainer>
+        <TextInput
+          label="상호명"
+          placeholder="상호명을 입력해주세요"
+          errorMessage="올바른 상호명을 입력해주세요"
+          error={isError(marketName)}
+          value={marketName}
+          onChange={e => setMarketName(e.nativeEvent.text)}
+        />
+      </S.RegisterManagerInputContainer>
+      <S.ConfirmLayout>
+        <TextInput
+          label="인증코드"
+          placeholder="인증코드를 입력해주세요(6자)"
+          errorMessage="올바른 인증코드를 입력해주세요"
+          error={isError(authCode, 6)}
+          value={authCode}
+          onChange={e => setAuthCode(e.nativeEvent.text)}
+        />
+        <S.ConfirmButton
+          disabled={
+            !marketName ||
+            isError(marketName) ||
+            !authCode ||
+            isError(authCode, 6)
+          }
+          onPress={() => {
+            handleValidtateAuthCode();
+          }}>
+          <S.ConfirmButtonText
+            disabled={
+              !marketName ||
+              isError(marketName) ||
+              !authCode ||
+              isError(authCode, 6)
+            }>
+            인증하기
+          </S.ConfirmButtonText>
+        </S.ConfirmButton>
+      </S.ConfirmLayout>
+    </S.RegisterManagerContainer>
+  );
+};
+
+export default RegisterManagerScreen;


### PR DESCRIPTION
## #️⃣연관된 이슈

resolves: #90 

<!-- resolves: #이슈번호, #이슈번호 -->

## 📝작업 내용

- 직원 등록 페이지 추가
- safeArea 수정
- apiClient 고객앱과 동기화
- manager/client.ts 에러 선제 반영

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

#### 인증 코드 생성 이후 직원 인증
https://github.com/user-attachments/assets/38bf14ad-67fd-4461-94f8-5274df4e706d

#### 사장 수락
https://github.com/user-attachments/assets/a9e0f2d3-6cb4-494d-b928-4726625f709b




### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

useProfile에 role을 추가해서 진행하려 했으나.. 페이지단에서 진행했습니다. 일단 변경 후 유지했습니다.

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
