### PR TITLE
feat: 매장 등록 시 사업자 인증 로직 추가

### DIFF
--- a/src/apis/markets/client.ts
+++ b/src/apis/markets/client.ts
@@ -131,11 +131,11 @@ export const verifyBusinessNumber = async (
   data: VerifyBusinessNumberRequest,
 ): Promise<boolean> => {
   try {
-    const res = await apiClient.get<{data: VerifyBusinessNumberResponse}>(
+    const res = await apiClient.get<VerifyBusinessNumberResponse>(
       'owner/markets/verification/business-number',
       {params: data},
     );
-    return !!res && res.data.validBusinessNumber;
+    return !!res && res.validBusinessNumber;
   } catch (error) {
     console.error(error);
     return false;

--- a/src/apis/markets/client.ts
+++ b/src/apis/markets/client.ts
@@ -4,7 +4,11 @@ import {
   UpdateMarketInfoType,
 } from '@/types/Market';
 import apiClient from '../ApiClient';
-import {MarketListResponse} from './model';
+import {
+  MarketListResponse,
+  VerifyBusinessNumberRequest,
+  VerifyBusinessNumberResponse,
+} from './model';
 
 /**
  * POST /markets
@@ -117,6 +121,21 @@ export const deleteMarketImage = async (imageUrl: string): Promise<boolean> => {
     });
 
     return !!res && res.code === 200;
+  } catch (error) {
+    console.error(error);
+    return false;
+  }
+};
+
+export const verifyBusinessNumber = async (
+  data: VerifyBusinessNumberRequest,
+): Promise<boolean> => {
+  try {
+    const res = await apiClient.get<{data: VerifyBusinessNumberResponse}>(
+      'owner/markets/verification/business-number',
+      {params: data},
+    );
+    return !!res && res.data.validBusinessNumber;
   } catch (error) {
     console.error(error);
     return false;

--- a/src/apis/markets/model.ts
+++ b/src/apis/markets/model.ts
@@ -9,3 +9,17 @@ export type MarketListResponse = {
   /** 가게명 */
   marketName: string;
 };
+
+export type verifyBusinessNumberInterface = {
+  businessNumber: string;
+  startDate: string;
+  name: string;
+  marketName: string;
+};
+
+export type VerifyBusinessNumberRequest = verifyBusinessNumberInterface;
+
+export type VerifyBusinessNumberResponse = {
+  validBusinessNumber: boolean;
+  businessNumberValidateInfoResponse: verifyBusinessNumberInterface;
+};

--- a/src/apis/markets/query.ts
+++ b/src/apis/markets/query.ts
@@ -72,7 +72,7 @@ export const useVerifyBusinessNumber = (
       : ['verifyBusinessNumber', 'idle'],
     queryFn: () => {
       if (!params) {
-        console.error('no params');
+        console.debug('no params');
         return;
       }
       return verifyBusinessNumber(params);

--- a/src/apis/markets/query.ts
+++ b/src/apis/markets/query.ts
@@ -6,8 +6,10 @@ import {
   getMarketList,
   updateMarketInfo,
   uploadMarketImage,
+  verifyBusinessNumber,
 } from './client';
 import {RegistMarketType, UpdateMarketInfoType} from '@/types/Market';
+import {VerifyBusinessNumberRequest} from './model';
 
 export const useCreateMarket = () => {
   return useMutation({
@@ -57,5 +59,22 @@ export const useDeleteMarketImage = (imageUrl: string) => {
   return useMutation({
     mutationKey: ['deleteMarketImage'],
     mutationFn: () => deleteMarketImage(imageUrl),
+  });
+};
+
+export const useVerifyBusinessNumber = (
+  params?: VerifyBusinessNumberRequest,
+) => {
+  return useQuery({
+    queryKey: ['verifyBusinessNumber'],
+    queryFn: () => {
+      if (!params) {
+        console.error('no params');
+        return;
+      }
+      return verifyBusinessNumber(params);
+    },
+    enabled: false,
+    staleTime: 0,
   });
 };

--- a/src/apis/markets/query.ts
+++ b/src/apis/markets/query.ts
@@ -64,9 +64,12 @@ export const useDeleteMarketImage = (imageUrl: string) => {
 
 export const useVerifyBusinessNumber = (
   params?: VerifyBusinessNumberRequest,
+  enabled: boolean = false,
 ) => {
   return useQuery({
-    queryKey: ['verifyBusinessNumber'],
+    queryKey: params
+      ? ['verifyBusinessNumber', params]
+      : ['verifyBusinessNumber', 'idle'],
     queryFn: () => {
       if (!params) {
         console.error('no params');
@@ -74,7 +77,7 @@ export const useVerifyBusinessNumber = (
       }
       return verifyBusinessNumber(params);
     },
-    enabled: false,
+    enabled: enabled && !!params,
     staleTime: 0,
   });
 };

--- a/src/screens/RegisterMarketScreen/RegisterMarketScreen.style.tsx
+++ b/src/screens/RegisterMarketScreen/RegisterMarketScreen.style.tsx
@@ -82,6 +82,12 @@ const S = {
     color: ${props => props.theme.colors.error};
     margin-top: 8px;
   `,
+
+  VerifiedBusinessText: styled(Text)`
+    ${({theme}) => theme.fonts.body2}
+    color: ${props => props.theme.colors.tertiary};
+    margin-bottom: 4px;
+  `,
 };
 
 export default S;

--- a/src/screens/RegisterMarketScreen/RegisterMarketScreen.style.tsx
+++ b/src/screens/RegisterMarketScreen/RegisterMarketScreen.style.tsx
@@ -22,7 +22,7 @@ const S = {
     gap: 20px;
   `,
 
-  AddressLayout: styled.View`
+  InputLayout: styled.View`
     display: flex;
     flex-direction: column;
 
@@ -36,9 +36,24 @@ const S = {
     border-radius: 8px;
   `,
 
-  PostcodeButtonText: styled(Text)`
-    color: #000000;
-    ${props => props.theme.fonts.default};
+  VerifyBusinessButton: styled(Button)<{disabled?: boolean}>`
+    background-color: ${props => {
+      if (props.disabled) {
+        return props.theme.colors.primaryDisabled;
+      }
+      return props.theme.colors.primary;
+    }};
+    border-radius: 8px;
+  `,
+
+  ButtonText: styled(Text)<{disabled?: boolean}>`
+    color: ${props => {
+        if (props.disabled) {
+          return props.theme.colors.tertiaryDisabled;
+        }
+        return props.theme.colors.dark;
+      }}
+      ${props => props.theme.fonts.default};
   `,
 
   ModalContainer: styled.View`

--- a/src/screens/RegisterMarketScreen/RegisterMarketScreen.style.tsx
+++ b/src/screens/RegisterMarketScreen/RegisterMarketScreen.style.tsx
@@ -3,7 +3,7 @@ import Postcode from '@actbase/react-daum-postcode';
 import {Button, Text} from 'react-native-paper';
 
 const S = {
-  RegisterMarketContainer: styled.View`
+  RegisterMarketContainer: styled.KeyboardAvoidingView`
     position: relative;
 
     flex: 1;

--- a/src/screens/RegisterMarketScreen/index.tsx
+++ b/src/screens/RegisterMarketScreen/index.tsx
@@ -200,7 +200,6 @@ const RegisterMarketScreen = () => {
                     disabled={disabledBusinessNumberVerifyButton}
                     onPress={() => {
                       verifyBusinessNumber();
-                      console.log(isInputIncomplete);
                     }}>
                     <S.ButtonText disabled={disabledBusinessNumberVerifyButton}>
                       사업자등록번호 인증

--- a/src/screens/RegisterMarketScreen/index.tsx
+++ b/src/screens/RegisterMarketScreen/index.tsx
@@ -119,7 +119,8 @@ const RegisterMarketScreen = () => {
         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
         <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
           <>
-            <S.RegisterMarketScrollContainer>
+            <S.RegisterMarketScrollContainer
+              contentContainerStyle={{paddingBottom: 24}}>
               <S.RegisterMarketInputContainer>
                 <S.InputLayout>
                   <TextInput

--- a/src/screens/RegisterMarketScreen/index.tsx
+++ b/src/screens/RegisterMarketScreen/index.tsx
@@ -47,6 +47,8 @@ const RegisterMarketScreen = () => {
   const [businessNumber, setBusinessNumber] = useState<string | undefined>(
     undefined,
   );
+  const [isBusinessNumberVerified, setIsBusinessNumberVerified] =
+    useState<boolean>(false);
   const [isPostcodeVisible, setPostcodeVisible] = useState(false);
   const [address, setAddress] = useState<string | undefined>(undefined);
   const [specificAddress, setSpecificAddress] = useState<string | undefined>(
@@ -73,6 +75,7 @@ const RegisterMarketScreen = () => {
       (contactNumber && isPhoneNumber(contactNumber)) ||
     !businessNumber ||
     isError(businessNumber, 10) ||
+    !isBusinessNumberVerified ||
     !address ||
     isError(address) ||
     !specificAddress ||
@@ -83,7 +86,7 @@ const RegisterMarketScreen = () => {
       <S.RegisterMarketContainer>
         <S.RegisterMarketScrollContainer>
           <S.RegisterMarketInputContainer>
-            <S.AddressLayout>
+            <S.InputLayout>
               <TextInput
                 label="주소"
                 placeholder="주소 검색을 통해 입력해주세요"
@@ -94,9 +97,9 @@ const RegisterMarketScreen = () => {
                 disabled
               />
               <S.PostcodeButton onPress={() => setPostcodeVisible(true)}>
-                <S.PostcodeButtonText>{'주소 검색하기'}</S.PostcodeButtonText>
+                <S.ButtonText>{'주소 검색하기'}</S.ButtonText>
               </S.PostcodeButton>
-            </S.AddressLayout>
+            </S.InputLayout>
             <TextInput
               label="상세 주소"
               placeholder="동과 호수를 입력해주세요"
@@ -135,16 +138,26 @@ const RegisterMarketScreen = () => {
                 setContactNumber(e.nativeEvent.text.replaceAll(/-/g, ''))
               }
             />
-            <TextInput
-              label="사업자등록번호"
-              placeholder="사업자등록번호를 입력해주세요(10자)"
-              errorMessage="사업자등록번호를 입력해주세요(10자)"
-              inputMode="numeric"
-              maxLength={10}
-              error={isError(businessNumber, 10)}
-              value={businessNumber}
-              onChange={e => setBusinessNumber(e.nativeEvent.text)}
-            />
+            <S.InputLayout>
+              <TextInput
+                label="사업자등록번호"
+                placeholder="사업자등록번호를 입력해주세요(10자)"
+                errorMessage="사업자등록번호를 입력해주세요(10자)"
+                inputMode="numeric"
+                maxLength={10}
+                error={isError(businessNumber, 10)}
+                value={businessNumber}
+                onChange={e => setBusinessNumber(e.nativeEvent.text)}
+              />
+              <S.VerifyBusinessButton
+                disabled={!businessNumber || isError(businessNumber, 10)}
+                onPress={() => setPostcodeVisible(true)}>
+                <S.ButtonText
+                  disabled={!businessNumber || isError(businessNumber, 10)}>
+                  사업자등록번호 인증
+                </S.ButtonText>
+              </S.VerifyBusinessButton>
+            </S.InputLayout>
           </S.RegisterMarketInputContainer>
           {disabledRegisterButton && (
             <S.Notice>모든 입력 사항은 필수 입력 사항입니다.</S.Notice>

--- a/src/screens/RegisterMarketScreen/index.tsx
+++ b/src/screens/RegisterMarketScreen/index.tsx
@@ -50,6 +50,7 @@ const RegisterMarketScreen = () => {
     undefined,
   );
 
+  // 사업자등록번호 정보가 filled 되었는지
   const disabledBusinessNumberVerifyButton =
     !businessNumber ||
     !isValidBusinessNumber(businessNumber) ||
@@ -80,20 +81,33 @@ const RegisterMarketScreen = () => {
     setPostcodeVisible(false);
   };
 
-  const disabledRegisterButton =
+  // 모든 인풋에 입력이 되었는지, 안되었으면 true
+  const isInputIncomplete =
     !marketName ||
     isError(marketName) ||
     !contactNumber ||
     isError(contactNumber, 11) ||
-    (contactNumber && isLocalNumber(contactNumber)) ===
-      (contactNumber && isPhoneNumber(contactNumber)) ||
+    (!isLocalNumber(contactNumber) && !isPhoneNumber(contactNumber)) ||
     !address ||
     isError(address) ||
     !specificAddress ||
     isError(specificAddress) ||
-    disabledBusinessNumberVerifyButton ||
-    !isVerifiedBusinessNumber;
+    !businessNumber ||
+    isError(businessNumber, 10) ||
+    !marketOwnerName ||
+    isError(marketOwnerName) ||
+    !startDate ||
+    !isValidStartDate(startDate);
 
+  // 입력 + 사업자 등록 인증까지 체크
+  const disabledRegisterButton = isInputIncomplete || !isVerifiedBusinessNumber;
+
+  const showNotice =
+    isInputIncomplete || (!isInputIncomplete && !isVerifiedBusinessNumber);
+
+  const noticeMessage = isInputIncomplete
+    ? '모든 입력 사항은 필수 입력 사항입니다.'
+    : '사업자등록번호 인증이 필요합니다.';
   return (
     <>
       <S.RegisterMarketContainer>
@@ -182,21 +196,17 @@ const RegisterMarketScreen = () => {
               />
               <S.VerifyBusinessButton
                 disabled={disabledBusinessNumberVerifyButton}
-                onPress={() => verifyBusinessNumber()}>
+                onPress={() => {
+                  verifyBusinessNumber();
+                  console.log(isInputIncomplete);
+                }}>
                 <S.ButtonText disabled={disabledBusinessNumberVerifyButton}>
                   사업자등록번호 인증
                 </S.ButtonText>
               </S.VerifyBusinessButton>
-              {!disabledRegisterButton && isVerifiedBusinessNumber && (
-                <S.VerifiedBusinessText>
-                  사업자등록번호 인증이 완료되었습니다.
-                </S.VerifiedBusinessText>
-              )}
             </S.InputLayout>
           </S.RegisterMarketInputContainer>
-          {disabledRegisterButton && (
-            <S.Notice>모든 입력 사항은 필수 입력 사항입니다.</S.Notice>
-          )}
+          {showNotice && <S.Notice>{noticeMessage}</S.Notice>}
         </S.RegisterMarketScrollContainer>
         <BottomButton
           disabled={disabledRegisterButton}

--- a/src/screens/RegisterMarketScreen/index.tsx
+++ b/src/screens/RegisterMarketScreen/index.tsx
@@ -1,6 +1,11 @@
 import {useNavigation} from '@react-navigation/native';
 import React, {useState} from 'react';
-import {Alert, Text} from 'react-native';
+import {
+  Alert,
+  Keyboard,
+  Platform,
+  TouchableWithoutFeedback,
+} from 'react-native';
 import {Modal} from 'react-native-paper';
 
 import {BottomButton} from '@/components/common';
@@ -110,136 +115,144 @@ const RegisterMarketScreen = () => {
     : '사업자등록번호 인증이 필요합니다.';
   return (
     <>
-      <S.RegisterMarketContainer>
-        <S.RegisterMarketScrollContainer>
-          <S.RegisterMarketInputContainer>
-            <S.InputLayout>
-              <TextInput
-                label="주소"
-                placeholder="주소 검색을 통해 입력해주세요"
-                errorMessage="올바른 주소를 입력해주세요"
-                error={isError(address)}
-                value={address}
-                onChange={e => setAddress(e.nativeEvent.text)}
-                disabled
-              />
-              <S.PostcodeButton onPress={() => setPostcodeVisible(true)}>
-                <S.ButtonText>{'주소 검색하기'}</S.ButtonText>
-              </S.PostcodeButton>
-            </S.InputLayout>
-            <TextInput
-              label="상세 주소"
-              placeholder="동과 호수를 입력해주세요"
-              errorMessage="상세주소를 입력해주세요"
-              error={isError(specificAddress)}
-              value={specificAddress}
-              disabled={!address || isError(address)}
-              onChange={e => setSpecificAddress(e.nativeEvent.text)}
-            />
-            <TextInput
-              label="사장님 성함"
-              placeholder="사장님 성함을 입력해주세요"
-              errorMessage="사장님 이름을 입력해주세요"
-              error={isError(marketOwnerName)}
-              value={marketOwnerName}
-              onChange={e => setMarketOwnerName(e.nativeEvent.text)}
-            />
-            <TextInput
-              label="가게명"
-              placeholder="가게명을 입력해주세요"
-              errorMessage="가게명을 입력해주세요"
-              error={isError(marketName)}
-              value={marketName}
-              onChange={e => setMarketName(e.nativeEvent.text)}
-            />
-            <TextInput
-              label="전화번호"
-              placeholder="010-1234-5678"
-              errorMessage="전화번호를 입력해주세요"
-              keyboardType="numeric"
-              error={isError(contactNumber, 11)}
-              maxLength={11}
-              value={
-                contactNumber && isPhoneNumber(contactNumber)
-                  ? contactNumber.replace(/(\d{3})(\d{4})(\d{4})/, '$1-$2-$3')
-                  : contactNumber && isLocalNumber(contactNumber)
-                    ? contactNumber.replace(
-                        /(\d{2,3})(\d{3,4})(\d{4})/,
-                        '$1-$2-$3',
-                      )
-                    : contactNumber
-              }
-              onChange={e =>
-                setContactNumber(e.nativeEvent.text.replaceAll(/-/g, ''))
-              }
-            />
-            <TextInput
-              label="개업일자"
-              placeholder="YYYYMMDD 형식으로 입력해주세요"
-              errorMessage="개업일자를 입력해주세요"
-              inputMode="numeric"
-              maxLength={8}
-              error={isError(startDate, 8)}
-              value={startDate}
-              onChange={e => setStartDate(e.nativeEvent.text)}
-            />
-            <S.InputLayout>
-              <TextInput
-                label="사업자등록번호"
-                placeholder="사업자등록번호를 입력해주세요(10자)"
-                errorMessage="사업자등록번호를 입력해주세요(10자)"
-                inputMode="numeric"
-                maxLength={10}
-                error={isError(businessNumber, 10)}
-                value={businessNumber}
-                onChange={e => setBusinessNumber(e.nativeEvent.text)}
-              />
-              <S.VerifyBusinessButton
-                disabled={disabledBusinessNumberVerifyButton}
-                onPress={() => {
-                  verifyBusinessNumber();
-                  console.log(isInputIncomplete);
-                }}>
-                <S.ButtonText disabled={disabledBusinessNumberVerifyButton}>
-                  사업자등록번호 인증
-                </S.ButtonText>
-              </S.VerifyBusinessButton>
-            </S.InputLayout>
-          </S.RegisterMarketInputContainer>
-          {showNotice && <S.Notice>{noticeMessage}</S.Notice>}
-        </S.RegisterMarketScrollContainer>
-        <BottomButton
-          disabled={disabledRegisterButton}
-          onPress={async () => {
-            if (
-              !marketName ||
-              !businessNumber ||
-              !address ||
-              !specificAddress ||
-              !contactNumber
-            ) {
-              return;
-            }
-            const res = await createMarket({
-              name: marketName,
-              businessNumber,
-              address,
-              specificAddress,
-              contactNumber,
-            });
+      <S.RegisterMarketContainer
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
+        <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+          <>
+            <S.RegisterMarketScrollContainer>
+              <S.RegisterMarketInputContainer>
+                <S.InputLayout>
+                  <TextInput
+                    label="주소"
+                    placeholder="주소 검색을 통해 입력해주세요"
+                    errorMessage="올바른 주소를 입력해주세요"
+                    error={isError(address)}
+                    value={address}
+                    onChange={e => setAddress(e.nativeEvent.text)}
+                    disabled
+                  />
+                  <S.PostcodeButton onPress={() => setPostcodeVisible(true)}>
+                    <S.ButtonText>{'주소 검색하기'}</S.ButtonText>
+                  </S.PostcodeButton>
+                </S.InputLayout>
+                <TextInput
+                  label="상세 주소"
+                  placeholder="동과 호수를 입력해주세요"
+                  errorMessage="상세주소를 입력해주세요"
+                  error={isError(specificAddress)}
+                  value={specificAddress}
+                  disabled={!address || isError(address)}
+                  onChange={e => setSpecificAddress(e.nativeEvent.text)}
+                />
+                <TextInput
+                  label="사장님 성함"
+                  placeholder="사장님 성함을 입력해주세요"
+                  errorMessage="사장님 이름을 입력해주세요"
+                  error={isError(marketOwnerName)}
+                  value={marketOwnerName}
+                  onChange={e => setMarketOwnerName(e.nativeEvent.text)}
+                />
+                <TextInput
+                  label="가게명"
+                  placeholder="가게명을 입력해주세요"
+                  errorMessage="가게명을 입력해주세요"
+                  error={isError(marketName)}
+                  value={marketName}
+                  onChange={e => setMarketName(e.nativeEvent.text)}
+                />
+                <TextInput
+                  label="전화번호"
+                  placeholder="010-1234-5678"
+                  errorMessage="전화번호를 입력해주세요"
+                  keyboardType="numeric"
+                  error={isError(contactNumber, 11)}
+                  maxLength={11}
+                  value={
+                    contactNumber && isPhoneNumber(contactNumber)
+                      ? contactNumber.replace(
+                          /(\d{3})(\d{4})(\d{4})/,
+                          '$1-$2-$3',
+                        )
+                      : contactNumber && isLocalNumber(contactNumber)
+                        ? contactNumber.replace(
+                            /(\d{2,3})(\d{3,4})(\d{4})/,
+                            '$1-$2-$3',
+                          )
+                        : contactNumber
+                  }
+                  onChange={e =>
+                    setContactNumber(e.nativeEvent.text.replaceAll(/-/g, ''))
+                  }
+                />
+                <TextInput
+                  label="개업일자"
+                  placeholder="YYYYMMDD 형식으로 입력해주세요"
+                  errorMessage="개업일자를 입력해주세요"
+                  inputMode="numeric"
+                  maxLength={8}
+                  error={isError(startDate, 8)}
+                  value={startDate}
+                  onChange={e => setStartDate(e.nativeEvent.text)}
+                />
+                <S.InputLayout>
+                  <TextInput
+                    label="사업자등록번호"
+                    placeholder="사업자등록번호를 입력해주세요(10자)"
+                    errorMessage="사업자등록번호를 입력해주세요(10자)"
+                    inputMode="numeric"
+                    maxLength={10}
+                    error={isError(businessNumber, 10)}
+                    value={businessNumber}
+                    onChange={e => setBusinessNumber(e.nativeEvent.text)}
+                  />
+                  <S.VerifyBusinessButton
+                    disabled={disabledBusinessNumberVerifyButton}
+                    onPress={() => {
+                      verifyBusinessNumber();
+                      console.log(isInputIncomplete);
+                    }}>
+                    <S.ButtonText disabled={disabledBusinessNumberVerifyButton}>
+                      사업자등록번호 인증
+                    </S.ButtonText>
+                  </S.VerifyBusinessButton>
+                </S.InputLayout>
+              </S.RegisterMarketInputContainer>
+              {showNotice && <S.Notice>{noticeMessage}</S.Notice>}
+            </S.RegisterMarketScrollContainer>
+            <BottomButton
+              disabled={disabledRegisterButton}
+              onPress={async () => {
+                if (
+                  !marketName ||
+                  !businessNumber ||
+                  !address ||
+                  !specificAddress ||
+                  !contactNumber
+                ) {
+                  return;
+                }
+                const res = await createMarket({
+                  name: marketName,
+                  businessNumber,
+                  address,
+                  specificAddress,
+                  contactNumber,
+                });
 
-            if (res && res.marketId) {
-              selectMarket(res.marketId);
+                if (res && res.marketId) {
+                  selectMarket(res.marketId);
 
-              Alert.alert('매장 등록이 완료되었습니다.');
+                  Alert.alert('매장 등록이 완료되었습니다.');
 
-              await refresh();
+                  await refresh();
 
-              navigation.goBack();
-            }
-          }}>
-          매장 등록
-        </BottomButton>
+                  navigation.goBack();
+                }
+              }}>
+              매장 등록
+            </BottomButton>
+          </>
+        </TouchableWithoutFeedback>
       </S.RegisterMarketContainer>
       <Modal
         visible={isPostcodeVisible}

--- a/src/screens/RegisterMarketScreen/index.tsx
+++ b/src/screens/RegisterMarketScreen/index.tsx
@@ -24,6 +24,8 @@ import {
   isPhoneNumber,
   isValidBusinessNumber,
   isValidStartDate,
+  deleteHyphen,
+  formatPhoneNumber,
 } from '@/utils/marketRegister';
 
 interface AddressData {
@@ -168,21 +170,9 @@ const RegisterMarketScreen = () => {
                   keyboardType="numeric"
                   error={isError(contactNumber, 11)}
                   maxLength={11}
-                  value={
-                    contactNumber && isPhoneNumber(contactNumber)
-                      ? contactNumber.replace(
-                          /(\d{3})(\d{4})(\d{4})/,
-                          '$1-$2-$3',
-                        )
-                      : contactNumber && isLocalNumber(contactNumber)
-                        ? contactNumber.replace(
-                            /(\d{2,3})(\d{3,4})(\d{4})/,
-                            '$1-$2-$3',
-                          )
-                        : contactNumber
-                  }
+                  value={formatPhoneNumber(contactNumber ?? '')}
                   onChange={e =>
-                    setContactNumber(e.nativeEvent.text.replaceAll(/-/g, ''))
+                    setContactNumber(deleteHyphen(e.nativeEvent.text))
                   }
                 />
                 <TextInput

--- a/src/screens/RegisterMarketScreen/index.tsx
+++ b/src/screens/RegisterMarketScreen/index.tsx
@@ -32,6 +32,14 @@ const isLocalNumber = (value: string) => {
 const isPhoneNumber = (value: string) => {
   return /^(01[0|1|6|7|8|9])(\d{3,4})(\d{4})$/g.test(value);
 };
+
+const isValidStartDate = (value: string) => {
+  return /^\d{8}$/.test(value);
+};
+
+const isValidBusinessNumber = (value: string) => {
+  return /^\d{10}$/.test(value);
+};
 interface AddressData {
   roadAddress: string;
   jibunAddress: string;
@@ -54,6 +62,10 @@ const RegisterMarketScreen = () => {
   const [specificAddress, setSpecificAddress] = useState<string | undefined>(
     undefined,
   );
+  const [startDate, setStartDate] = useState<string | undefined>(undefined);
+  const [marketOwnerName, setMarketOwnerName] = useState<string | undefined>(
+    undefined,
+  );
   const [contactNumber, setContactNumber] = useState<string | undefined>(
     undefined,
   );
@@ -66,6 +78,16 @@ const RegisterMarketScreen = () => {
     setPostcodeVisible(false);
   };
 
+  const disabledBusinessNumberVerifyButton =
+    !marketOwnerName ||
+    isError(marketOwnerName) ||
+    !marketName ||
+    isError(marketName) ||
+    !startDate ||
+    !isValidStartDate(startDate) ||
+    !businessNumber ||
+    !isValidBusinessNumber(businessNumber);
+
   const disabledRegisterButton =
     !marketName ||
     isError(marketName) ||
@@ -73,13 +95,11 @@ const RegisterMarketScreen = () => {
     isError(contactNumber, 11) ||
     (contactNumber && isLocalNumber(contactNumber)) ===
       (contactNumber && isPhoneNumber(contactNumber)) ||
-    !businessNumber ||
-    isError(businessNumber, 10) ||
-    !isBusinessNumberVerified ||
     !address ||
     isError(address) ||
     !specificAddress ||
-    isError(specificAddress);
+    isError(specificAddress) ||
+    disabledBusinessNumberVerifyButton;
 
   return (
     <>
@@ -110,6 +130,14 @@ const RegisterMarketScreen = () => {
               onChange={e => setSpecificAddress(e.nativeEvent.text)}
             />
             <TextInput
+              label="사장님 성함"
+              placeholder="사장님 성함을 입력해주세요"
+              errorMessage="사장님 이름을 입력해주세요"
+              error={isError(marketOwnerName)}
+              value={marketOwnerName}
+              onChange={e => setMarketOwnerName(e.nativeEvent.text)}
+            />
+            <TextInput
               label="가게명"
               placeholder="가게명을 입력해주세요"
               errorMessage="가게명을 입력해주세요"
@@ -138,6 +166,16 @@ const RegisterMarketScreen = () => {
                 setContactNumber(e.nativeEvent.text.replaceAll(/-/g, ''))
               }
             />
+            <TextInput
+              label="개업일자"
+              placeholder="YYYYMMDD 형식으로 입력해주세요"
+              errorMessage="개업일자를 입력해주세요"
+              inputMode="numeric"
+              maxLength={8}
+              error={isError(startDate, 8)}
+              value={startDate}
+              onChange={e => setStartDate(e.nativeEvent.text)}
+            />
             <S.InputLayout>
               <TextInput
                 label="사업자등록번호"
@@ -150,10 +188,9 @@ const RegisterMarketScreen = () => {
                 onChange={e => setBusinessNumber(e.nativeEvent.text)}
               />
               <S.VerifyBusinessButton
-                disabled={!businessNumber || isError(businessNumber, 10)}
+                disabled={disabledBusinessNumberVerifyButton}
                 onPress={() => setPostcodeVisible(true)}>
-                <S.ButtonText
-                  disabled={!businessNumber || isError(businessNumber, 10)}>
+                <S.ButtonText disabled={disabledBusinessNumberVerifyButton}>
                   사업자등록번호 인증
                 </S.ButtonText>
               </S.VerifyBusinessButton>

--- a/src/utils/marketRegister.ts
+++ b/src/utils/marketRegister.ts
@@ -25,3 +25,17 @@ export const isValidStartDate = (value: string) => {
 export const isValidBusinessNumber = (value: string) => {
   return /^\d{10}$/.test(value);
 };
+
+export const formatPhoneNumber = (value: string): string => {
+  if (isPhoneNumber(value)) {
+    return value.replace(/(\d{3})(\d{4})(\d{4})/, '$1-$2-$3');
+  }
+  if (isLocalNumber(value)) {
+    return value.replace(/(\d{2,3})(\d{3,4})(\d{4})/, '$1-$2-$3');
+  }
+  return value;
+};
+
+export const deleteHyphen = (value: string) => {
+  return value.replaceAll(/-/g, '');
+};

--- a/src/utils/marketRegister.ts
+++ b/src/utils/marketRegister.ts
@@ -1,0 +1,27 @@
+export const isError = (value: string | undefined, validLength?: number) => {
+  if (value === undefined) {
+    return false;
+  }
+
+  if (value.length === 0) {
+    return true;
+  }
+
+  return !!validLength && value?.length !== validLength;
+};
+
+export const isLocalNumber = (value: string) => {
+  return /^(0(2|3[1-3]|4[1-4]|5[1-5]|6[1-4]))(\d{3,4})(\d{4})$/g.test(value);
+};
+
+export const isPhoneNumber = (value: string) => {
+  return /^(01[0|1|6|7|8|9])(\d{3,4})(\d{4})$/g.test(value);
+};
+
+export const isValidStartDate = (value: string) => {
+  return /^\d{8}$/.test(value);
+};
+
+export const isValidBusinessNumber = (value: string) => {
+  return /^\d{10}$/.test(value);
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->

## 📝작업 내용

- 매장 등록 사업자 등록번호 인증 로직
- 매장 등록 페이지 스크롤뷰, 키보드 이슈 정상화

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

https://github.com/user-attachments/assets/015d59ac-4c66-4540-928d-a91ce907a424


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

useVerifyBusinessNumber() 쿼리키 확인한번 부탁드립니다
params 유무에 따라 쿼리키가 갱신되어 undefined도 안들어가고, 
인증된 사업자등록번호에서 다른 정보를 입력하거나 한글자 지우면 바로 갱신되어 false 반환되어 버튼 disabled
캐시는 유지되어 기존 인증되었던 정보는 유지중

저희 고민했던 queryKey가 undefined일때,
get 요청이라서 useQuery를 사용하는데, 리스폰스를 just read가 아니라 그에 따라 상호작용이 필요할 때
useEffect 안쓰고 best practice인진 모르겠지만 나름 괜찮아 보입니다.
enabled도 외부에서 주입할까 하다 일단 기본값으로 유지했습니다.

인풋들 상태에 따라 조건 부여 수정했습니다.
한참 생각했는데 놓친 부분 있을 수도 있어서 boolean 값들도 같이 봐주시면 감사하겠습니다.

아래 세가지를 UX라이팅 한줄로 해결하려고 해서 좀 복잡해진 것 같습니다.
1. 전부 입력이 되지 않았을 때
2. 입력은 되었지만 인증이 안되었을 때
3. 입력, 인증 O