### PR TITLE
fix: 주문 내역 접속 시 fetch 페이지 단에서 감시

### DIFF
--- a/src/apis/orders/query.ts
+++ b/src/apis/orders/query.ts
@@ -4,13 +4,13 @@ import {getPendingOrderLists, updateOrderStatus} from './client';
 
 export const useGetOrders = ({ordersStatus, marketId}: OrdersRequest) => {
   return useQuery({
-    queryKey: ['orders', ordersStatus, marketId, Date.now()],
+    queryKey: ['orders', ordersStatus, marketId],
     queryFn: () => {
       if (!marketId) return null;
       return getPendingOrderLists({ordersStatus, marketId});
     },
     enabled: marketId !== 0,
-    staleTime: 1000 * 60 * 5,
+    staleTime: 1000,
     placeholderData: keepPreviousData,
     refetchOnMount: 'always',
   });

--- a/src/apis/orders/query.ts
+++ b/src/apis/orders/query.ts
@@ -10,7 +10,7 @@ export const useGetOrders = ({ordersStatus, marketId}: OrdersRequest) => {
       return getPendingOrderLists({ordersStatus, marketId});
     },
     enabled: marketId !== 0,
-    staleTime: 1000,
+    staleTime: 1000 * 60 * 5,
     placeholderData: keepPreviousData,
     refetchOnMount: 'always',
   });

--- a/src/screens/OrderHistoryScreen/index.tsx
+++ b/src/screens/OrderHistoryScreen/index.tsx
@@ -1,6 +1,6 @@
-import React, {useState} from 'react';
+import React, {useState, useCallback} from 'react';
 import {View} from 'react-native';
-
+import {useFocusEffect} from '@react-navigation/native';
 import {ToggleButton} from '@/components/common';
 import EmptyMarket from '@/components/common/EmptyMarket';
 import NonRegister from '@/components/common/NonRegister';
@@ -20,13 +20,20 @@ const OrderHistoryScreen = () => {
   const {profile} = useProfile();
   const marketId = profile?.marketId;
 
-  const {marketInfo} = useMarket();
   const {
     data: orders,
     refetch,
     isLoading: getOrderLoading,
   } = useGetOrders({marketId: marketId ?? 0, ordersStatus: selected});
   const {onRefresh, refreshing} = usePullDownRefresh(refetch);
+  const {marketInfo} = useMarket();
+  useFocusEffect(
+    useCallback(() => {
+      if (marketId) {
+        refetch();
+      }
+    }, [marketId, refetch]),
+  );
 
   if (!profile) {
     return <NonRegister />;
@@ -39,6 +46,7 @@ const OrderHistoryScreen = () => {
   if (getOrderLoading || !orders) {
     return <ActivityIndicator />;
   }
+
   return (
     <View>
       <S.NavbarGroup selected={selected}>


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

## 스크린샷

https://github.com/user-attachments/assets/3c6d7e96-7fb8-49fc-bbe2-b36ace1375b1



## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

queryKey가 Date.now()여서 계속 쏘는 것 같습니다.
페이지 접속 감지를 useFocusEffect로 진행했습니다!


