### PR TITLE
fix: 가게 등록 페이지 iOS 키보드 패딩 추가

### DIFF
--- a/src/screens/RegisterMarketScreen/RegisterMarketScreen.style.tsx
+++ b/src/screens/RegisterMarketScreen/RegisterMarketScreen.style.tsx
@@ -13,6 +13,11 @@ const S = {
     padding: 16px;
   `,
 
+  ColSpacer: styled.View`
+    height: 32px;
+    width: 100%;
+  `,
+
   RegisterMarketInputContainer: styled.View`
     display: flex;
     flex-direction: column;

--- a/src/screens/RegisterMarketScreen/RegisterMarketScreen.style.tsx
+++ b/src/screens/RegisterMarketScreen/RegisterMarketScreen.style.tsx
@@ -10,8 +10,6 @@ const S = {
   `,
 
   RegisterMarketScrollContainer: styled.ScrollView`
-    flex: 1;
-
     padding: 16px;
   `,
 

--- a/src/screens/RegisterMarketScreen/index.tsx
+++ b/src/screens/RegisterMarketScreen/index.tsx
@@ -150,7 +150,7 @@ const RegisterMarketScreen = () => {
         <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
           <>
             <S.RegisterMarketScrollContainer
-              contentContainerStyle={{paddingBottom: 24, flexGrow: 1}}>
+              contentContainerStyle={{paddingBottom: 24}}>
               <S.RegisterMarketInputContainer>
                 <S.InputLayout>
                   <TextInput

--- a/src/screens/RegisterMarketScreen/index.tsx
+++ b/src/screens/RegisterMarketScreen/index.tsx
@@ -145,11 +145,12 @@ const RegisterMarketScreen = () => {
   return (
     <>
       <S.RegisterMarketContainer
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        keyboardVerticalOffset={Platform.OS === 'ios' ? 80 : 0}>
         <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
           <>
             <S.RegisterMarketScrollContainer
-              contentContainerStyle={{paddingBottom: 24}}>
+              contentContainerStyle={{paddingBottom: 24, flexGrow: 1}}>
               <S.RegisterMarketInputContainer>
                 <S.InputLayout>
                   <TextInput

--- a/src/screens/RegisterMarketScreen/index.tsx
+++ b/src/screens/RegisterMarketScreen/index.tsx
@@ -149,8 +149,7 @@ const RegisterMarketScreen = () => {
         keyboardVerticalOffset={Platform.OS === 'ios' ? 90 : 0}>
         <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
           <>
-            <S.RegisterMarketScrollContainer
-              contentContainerStyle={{paddingBottom: 24}}>
+            <S.RegisterMarketScrollContainer>
               <S.RegisterMarketInputContainer>
                 <S.InputLayout>
                   <TextInput
@@ -253,6 +252,7 @@ const RegisterMarketScreen = () => {
                 </S.InputLayout>
               </S.RegisterMarketInputContainer>
               {showNotice && <S.Notice>{noticeMessage}</S.Notice>}
+              <S.ColSpacer />
             </S.RegisterMarketScrollContainer>
             <BottomButton
               disabled={disabledRegisterButton}

--- a/src/screens/RegisterMarketScreen/index.tsx
+++ b/src/screens/RegisterMarketScreen/index.tsx
@@ -146,7 +146,7 @@ const RegisterMarketScreen = () => {
     <>
       <S.RegisterMarketContainer
         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        keyboardVerticalOffset={Platform.OS === 'ios' ? 80 : 0}>
+        keyboardVerticalOffset={Platform.OS === 'ios' ? 90 : 0}>
         <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
           <>
             <S.RegisterMarketScrollContainer


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

키보드가 바텀 패딩은 잡고 있는데, 저희 고정 바텀버튼에 가려졌던 것으로 판단됩니다.
keyboardVerticalOffset이용하여 키보드가 올라갈때 화면이 얼마나 올라가는지 조정하여 해결된 것으로 판단됩니다.



### 스크린샷 (선택)

<img src="https://github.com/user-attachments/assets/06948cb2-0fb1-49e5-83d7-e4cd62eeab31" width="360" />

<img src="https://github.com/user-attachments/assets/3413b980-5236-467b-beba-18b0697f4d1f" width="360" />


## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->


해당 속성 사용해 바텀버튼이 키보드 위로 항상 붙어오는데 피드백 부탁드립니다.