### PR TITLE
fix: 키보드 가림 방지 및 ux 개선

### DIFF
--- a/src/components/LoginPage/CredentialLogin.style.tsx
+++ b/src/components/LoginPage/CredentialLogin.style.tsx
@@ -2,6 +2,9 @@ import styled from '@emotion/native';
 import {Button} from 'react-native-paper';
 
 const S = {
+  Container: styled.KeyboardAvoidingView`
+    flex: 1;
+  `,
   ScreenWrapper: styled.ScrollView`
     flex: 1;
 

--- a/src/components/LoginPage/CredentialSignUp.tsx
+++ b/src/components/LoginPage/CredentialSignUp.tsx
@@ -1,7 +1,12 @@
 import {useNavigation} from '@react-navigation/native';
 import {StackNavigationProp} from '@react-navigation/stack';
 import React, {useState} from 'react';
-import {Alert} from 'react-native';
+import {
+  Alert,
+  Platform,
+  Keyboard,
+  TouchableWithoutFeedback,
+} from 'react-native';
 import {ActivityIndicator} from 'react-native-paper';
 
 import useProfile from '@/hooks/useProfile';
@@ -65,150 +70,156 @@ const CredentialSignUp = () => {
   const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
 
   return (
-    <S.ScreenWrapper>
-      <S.LoginFormWrapper>
-        <TextInput
-          label={'이름'}
-          placeholder={'이름'}
-          value={name}
-          onChange={e => setName(e.nativeEvent.text)}
-          validation={validateNameLength}
-          errorMessage="이름은 2자 이상 10자 이하로 입력해주세요."
-        />
-        <S.EmailVerifyContainer>
-          <TextInput
-            label={'이메일'}
-            placeholder={'이메일'}
-            value={email}
-            onChange={e => setEmail(e.nativeEvent.text)}
-            validation={validateEmail}
-            keyboardType="email-address"
-          />
-          <S.SendEmailCodeButton
-            disabled={!validateEmail(email) || isPendingSendEmailCode}
-            onPress={() => {
-              setIsValidationEmail(false);
-              setEmailCode('');
-              sendEmailCode(
-                {email},
-                {
-                  onSuccess: setIsPendingValidationEmail,
-                  onError: error =>
-                    Alert.alert(error.errorMessage ?? error.message),
-                },
-              );
-            }}>
-            {isPendingSendEmailCode
-              ? '인증번호 발송 중'
-              : isPendingValidationEmail
-                ? '인증번호 재발송'
-                : '인증번호 발송'}
-          </S.SendEmailCodeButton>
-          {isPendingSendEmailCode && (
-            <ActivityIndicator size="small" animating={true} />
-          )}
-        </S.EmailVerifyContainer>
-        {isPendingValidationEmail && (
-          <S.EmailVerifyContainer>
+    <S.Container
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      keyboardVerticalOffset={Platform.OS === 'ios' ? 100 : 0}>
+      <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+        <S.ScreenWrapper>
+          <S.LoginFormWrapper>
             <TextInput
-              label="인증번호"
-              placeholder="XXXXXX"
-              value={emailCode}
-              onChange={e => setEmailCode(e.nativeEvent.text)}
-              validation={validateEmailCode}
-              errorMessage="인증코드 6자리를 입력해주세요."
-              disabled={isValidationEmail}
+              label={'이름'}
+              placeholder={'이름'}
+              value={name}
+              onChange={e => setName(e.nativeEvent.text)}
+              validation={validateNameLength}
+              errorMessage="이름은 2자 이상 10자 이하로 입력해주세요."
             />
-            <S.VerifyEmailCodeButton
-              disabled={
-                !validateEmailCode(emailCode) ||
-                isPendingVerifyEmailCode ||
-                isValidationEmail
-              }
-              onPress={() =>
-                verifyEmailCode(
-                  {email, code: emailCode},
-                  {
-                    onSuccess: setIsValidationEmail,
-                  },
-                )
-              }>
-              {'인증번호 확인'}
-            </S.VerifyEmailCodeButton>
-          </S.EmailVerifyContainer>
-        )}
-        {isValidationEmail && (
-          <>
-            <TextInput
-              label={'비밀번호'}
-              placeholder={'비밀번호'}
-              value={password}
-              onChange={e => setPassword(e.nativeEvent.text)}
-              validation={validatePasswordLength}
-              errorMessage="비밀번호는 8자 이상으로 입력해주세요."
-              secureTextEntry
-            />
-            <TextInput
-              label={'비밀번호 확인'}
-              placeholder={'비밀번호 확인'}
-              value={passwordCheck}
-              onChange={e => setPasswordCheck(e.nativeEvent.text)}
-              secureTextEntry
-              validation={() => validatePassword(password, passwordCheck)}
-              errorMessage="비밀번호가 일치하지 않습니다."
-            />
-            <TextInput
-              label={'전화번호'}
-              placeholder={'010-1234-5678'}
-              value={phoneNumber}
-              onChange={e => {
-                const value = e.nativeEvent.text;
-                if (value.length === 11) {
-                  // set 01012345678 -> 010-1234-5678
-                  const formatted = value.replace(
-                    /(\d{3})(\d{4})(\d{4})/,
-                    '$1-$2-$3',
+            <S.EmailVerifyContainer>
+              <TextInput
+                label={'이메일'}
+                placeholder={'이메일'}
+                value={email}
+                onChange={e => setEmail(e.nativeEvent.text)}
+                validation={validateEmail}
+                keyboardType="email-address"
+              />
+              <S.SendEmailCodeButton
+                disabled={!validateEmail(email) || isPendingSendEmailCode}
+                onPress={() => {
+                  setIsValidationEmail(false);
+                  setEmailCode('');
+                  sendEmailCode(
+                    {email},
+                    {
+                      onSuccess: setIsPendingValidationEmail,
+                      onError: error =>
+                        Alert.alert(error.errorMessage ?? error.message),
+                    },
                   );
-                  setPhoneNumber(formatted);
-                } else {
-                  setPhoneNumber(value);
+                }}>
+                {isPendingSendEmailCode
+                  ? '인증번호 발송 중'
+                  : isPendingValidationEmail
+                    ? '인증번호 재발송'
+                    : '인증번호 발송'}
+              </S.SendEmailCodeButton>
+              {isPendingSendEmailCode && (
+                <ActivityIndicator size="small" animating={true} />
+              )}
+            </S.EmailVerifyContainer>
+            {isPendingValidationEmail && (
+              <S.EmailVerifyContainer>
+                <TextInput
+                  label="인증번호"
+                  placeholder="XXXXXX"
+                  value={emailCode}
+                  onChange={e => setEmailCode(e.nativeEvent.text)}
+                  validation={validateEmailCode}
+                  errorMessage="인증코드 6자리를 입력해주세요."
+                  disabled={isValidationEmail}
+                />
+                <S.VerifyEmailCodeButton
+                  disabled={
+                    !validateEmailCode(emailCode) ||
+                    isPendingVerifyEmailCode ||
+                    isValidationEmail
+                  }
+                  onPress={() =>
+                    verifyEmailCode(
+                      {email, code: emailCode},
+                      {
+                        onSuccess: setIsValidationEmail,
+                      },
+                    )
+                  }>
+                  {'인증번호 확인'}
+                </S.VerifyEmailCodeButton>
+              </S.EmailVerifyContainer>
+            )}
+            {isValidationEmail && (
+              <>
+                <TextInput
+                  label={'비밀번호'}
+                  placeholder={'비밀번호'}
+                  value={password}
+                  onChange={e => setPassword(e.nativeEvent.text)}
+                  validation={validatePasswordLength}
+                  errorMessage="비밀번호는 8자 이상으로 입력해주세요."
+                  secureTextEntry
+                />
+                <TextInput
+                  label={'비밀번호 확인'}
+                  placeholder={'비밀번호 확인'}
+                  value={passwordCheck}
+                  onChange={e => setPasswordCheck(e.nativeEvent.text)}
+                  secureTextEntry
+                  validation={() => validatePassword(password, passwordCheck)}
+                  errorMessage="비밀번호가 일치하지 않습니다."
+                />
+                <TextInput
+                  label={'전화번호'}
+                  placeholder={'010-1234-5678'}
+                  value={phoneNumber}
+                  onChange={e => {
+                    const value = e.nativeEvent.text;
+                    if (value.length === 11) {
+                      // set 01012345678 -> 010-1234-5678
+                      const formatted = value.replace(
+                        /(\d{3})(\d{4})(\d{4})/,
+                        '$1-$2-$3',
+                      );
+                      setPhoneNumber(formatted);
+                    } else {
+                      setPhoneNumber(value);
+                    }
+                  }}
+                  validation={validatePhoneNumber}
+                  errorMessage="전화번호 형식을 맞춰주세요. (010-1234-5678)"
+                  keyboardType="phone-pad"
+                  maxLength={13}
+                />
+              </>
+            )}
+            <S.SubmitButton
+              mode="contained"
+              disabled={!name || !email || !password || !phoneNumber}
+              onPress={async () => {
+                if (password !== passwordCheck) {
+                  Alert.alert('비밀번호가 일치하지 않습니다.');
+                  return;
                 }
-              }}
-              validation={validatePhoneNumber}
-              errorMessage="전화번호 형식을 맞춰주세요. (010-1234-5678)"
-              keyboardType="phone-pad"
-              maxLength={13}
-            />
-          </>
-        )}
-        <S.SubmitButton
-          mode="contained"
-          disabled={!name || !email || !password || !phoneNumber}
-          onPress={async () => {
-            if (password !== passwordCheck) {
-              Alert.alert('비밀번호가 일치하지 않습니다.');
-              return;
-            }
 
-            signUp(
-              {
-                email,
-                password,
-                name,
-                phoneNumber,
-              },
-              {
-                onSuccess: () =>
-                  navigation.navigate('Register', {screen: 'Login'}),
-                onError: error =>
-                  Alert.alert(error.errorMessage ?? error.message),
-              },
-            );
-          }}>
-          회원가입
-        </S.SubmitButton>
-      </S.LoginFormWrapper>
-    </S.ScreenWrapper>
+                signUp(
+                  {
+                    email,
+                    password,
+                    name,
+                    phoneNumber,
+                  },
+                  {
+                    onSuccess: () =>
+                      navigation.navigate('Register', {screen: 'Login'}),
+                    onError: error =>
+                      Alert.alert(error.errorMessage ?? error.message),
+                  },
+                );
+              }}>
+              회원가입
+            </S.SubmitButton>
+          </S.LoginFormWrapper>
+        </S.ScreenWrapper>
+      </TouchableWithoutFeedback>
+    </S.Container>
   );
 };
 

--- a/src/components/menu/MenuModal.style.tsx
+++ b/src/components/menu/MenuModal.style.tsx
@@ -2,6 +2,10 @@ import styled from '@emotion/native';
 import {ScrollView} from 'react-native-gesture-handler';
 
 const S = {
+  Container: styled.KeyboardAvoidingView`
+    flex: 1;
+  `,
+
   ModalOverlay: styled.View`
     display: flex;
     flex: 1;

--- a/src/components/menu/MenuModal.tsx
+++ b/src/components/menu/MenuModal.tsx
@@ -3,7 +3,14 @@ import CustomTextInput from '@/components/common/CustomTextInput';
 import {MenuType, TagType} from '@/types/ProductType';
 import {pickImage} from '@/utils/image-picker';
 import React, {useEffect, useState} from 'react';
-import {Alert, Modal, SafeAreaView} from 'react-native';
+import {
+  Alert,
+  Modal,
+  SafeAreaView,
+  Platform,
+  Keyboard,
+  TouchableWithoutFeedback,
+} from 'react-native';
 import TextInput from '../common/TextInput/TextInput';
 import CustomLabel from '../common/CustomLabel';
 import TagModal from './TagModal';
@@ -210,114 +217,122 @@ const MenuModal = ({
     <Modal visible={isVisible} transparent={true} animationType="slide">
       <S.ModalOverlay>
         <SafeAreaView>
-          <S.ModalView>
-            <S.ModalCloseButton onPress={onClose}>
-              <Icon name="close" size={24} />
-            </S.ModalCloseButton>
-            <S.ModalScrollView>
-              <S.ModalViewInner>
-                <S.ModalImageWrapper onPress={handleImageUpload}>
-                  {menuData.image ? (
-                    <S.ModalImage source={{uri: menuData.image}} />
-                  ) : (
-                    <S.ModalButton onPress={handleImageUpload}>
-                      <S.ModalButtonText>이미지 선택하기</S.ModalButtonText>
-                    </S.ModalButton>
-                  )}
-                </S.ModalImageWrapper>
-                <S.InputRow>
-                  <TextInput
-                    value={menuData.name}
-                    placeholder="메뉴 이름 입력"
-                    onChangeText={text => handleInputChange('name', text)}
-                  />
-                </S.InputRow>
-                <S.InputRow>
-                  <S.ModalButton onPress={() => setTagModalVisible(true)}>
-                    <S.StatusButtonText>태그 추가하기</S.StatusButtonText>
-                  </S.ModalButton>
-                  <S.TagsFlexWrap>
-                    {menuData.tags.map(tag => (
-                      <S.TagButtonWrapper key={tag.id}>
-                        <S.StatusButtonText>{tag.tagName}</S.StatusButtonText>
-                      </S.TagButtonWrapper>
-                    ))}
-                  </S.TagsFlexWrap>
-                </S.InputRow>
-                <S.InputRow>
-                  <CustomLabel label={'원가'} required />
-                  <CustomTextInput
-                    value={menuData.originPrice.toString()}
-                    onChangeText={text =>
-                      handleInputChange('originPrice', text)
-                    }
-                  />
-                </S.InputRow>
-                <S.InputRow>
-                  <CustomLabel label={'할인가'} required />
-                  <CustomTextInput
-                    value={menuData.discountPrice.toString()}
-                    onChangeText={text =>
-                      handleInputChange('discountPrice', text)
-                    }
-                  />
-                </S.InputRow>
-
-                <S.InputRow>
-                  <S.InputLabel>적용 할인율</S.InputLabel>
-                  <CustomTextInput
-                    value={menuData.discountRate.toString() + '%'}
-                    disabled
-                  />
-                </S.InputRow>
-                <S.InputRow>
-                  <CustomLabel label={'재고'} required />
-                  <CustomTextInput
-                    value={menuData.stock.toString()}
-                    onChangeText={text => handleInputChange('stock', text)}
-                  />
-                </S.InputRow>
-                <S.InputRow>
-                  <S.InputLabel>판매 상태</S.InputLabel>
-                  <S.StatusButtonContainer>
-                    {Object.entries(STATUS_OPTIONS).map(([status, label]) => (
-                      <S.StatusButton
-                        key={status}
-                        onPress={() =>
-                          handleStatusChange(
-                            status as MenuType['productStatus'],
-                          )
+          <S.Container behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
+            <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+              <S.ModalView>
+                <S.ModalCloseButton onPress={onClose}>
+                  <Icon name="close" size={24} />
+                </S.ModalCloseButton>
+                <S.ModalScrollView>
+                  <S.ModalViewInner>
+                    <S.ModalImageWrapper onPress={handleImageUpload}>
+                      {menuData.image ? (
+                        <S.ModalImage source={{uri: menuData.image}} />
+                      ) : (
+                        <S.ModalButton onPress={handleImageUpload}>
+                          <S.ModalButtonText>이미지 선택하기</S.ModalButtonText>
+                        </S.ModalButton>
+                      )}
+                    </S.ModalImageWrapper>
+                    <S.InputRow>
+                      <TextInput
+                        value={menuData.name}
+                        placeholder="메뉴 이름 입력"
+                        onChangeText={text => handleInputChange('name', text)}
+                      />
+                    </S.InputRow>
+                    <S.InputRow>
+                      <S.ModalButton onPress={() => setTagModalVisible(true)}>
+                        <S.StatusButtonText>태그 추가하기</S.StatusButtonText>
+                      </S.ModalButton>
+                      <S.TagsFlexWrap>
+                        {menuData.tags.map(tag => (
+                          <S.TagButtonWrapper key={tag.id}>
+                            <S.StatusButtonText>
+                              {tag.tagName}
+                            </S.StatusButtonText>
+                          </S.TagButtonWrapper>
+                        ))}
+                      </S.TagsFlexWrap>
+                    </S.InputRow>
+                    <S.InputRow>
+                      <CustomLabel label={'원가'} required />
+                      <CustomTextInput
+                        value={menuData.originPrice.toString()}
+                        onChangeText={text =>
+                          handleInputChange('originPrice', text)
                         }
-                        isActive={menuData.productStatus === status}>
-                        <S.StatusButtonText>{label}</S.StatusButtonText>
-                      </S.StatusButton>
-                    ))}
-                  </S.StatusButtonContainer>
-                </S.InputRow>
+                      />
+                    </S.InputRow>
+                    <S.InputRow>
+                      <CustomLabel label={'할인가'} required />
+                      <CustomTextInput
+                        value={menuData.discountPrice.toString()}
+                        onChangeText={text =>
+                          handleInputChange('discountPrice', text)
+                        }
+                      />
+                    </S.InputRow>
 
-                <S.ButtonContainer>
-                  <S.ModalButton onPress={handleSave}>
-                    <S.ModalButtonText>저장</S.ModalButtonText>
-                  </S.ModalButton>
-                  <S.ModalButton onPress={onClose} status="warning">
-                    <S.ModalButtonText>취소</S.ModalButtonText>
-                  </S.ModalButton>
-                  {initialData && (
-                    <S.ModalButton onPress={handleDelete} status="error">
-                      <S.ModalButtonText>삭제</S.ModalButtonText>
-                    </S.ModalButton>
-                  )}
-                </S.ButtonContainer>
-                <TagModal
-                  isVisible={tagModalVisible}
-                  onClose={() => setTagModalVisible(false)}
-                  onSave={handleTagsUpdate}
-                  initialTags={initialData?.tags}
-                  presetTags={presetTags}
-                />
-              </S.ModalViewInner>
-            </S.ModalScrollView>
-          </S.ModalView>
+                    <S.InputRow>
+                      <S.InputLabel>적용 할인율</S.InputLabel>
+                      <CustomTextInput
+                        value={menuData.discountRate.toString() + '%'}
+                        disabled
+                      />
+                    </S.InputRow>
+                    <S.InputRow>
+                      <CustomLabel label={'재고'} required />
+                      <CustomTextInput
+                        value={menuData.stock.toString()}
+                        onChangeText={text => handleInputChange('stock', text)}
+                      />
+                    </S.InputRow>
+                    <S.InputRow>
+                      <S.InputLabel>판매 상태</S.InputLabel>
+                      <S.StatusButtonContainer>
+                        {Object.entries(STATUS_OPTIONS).map(
+                          ([status, label]) => (
+                            <S.StatusButton
+                              key={status}
+                              onPress={() =>
+                                handleStatusChange(
+                                  status as MenuType['productStatus'],
+                                )
+                              }
+                              isActive={menuData.productStatus === status}>
+                              <S.StatusButtonText>{label}</S.StatusButtonText>
+                            </S.StatusButton>
+                          ),
+                        )}
+                      </S.StatusButtonContainer>
+                    </S.InputRow>
+
+                    <S.ButtonContainer>
+                      <S.ModalButton onPress={handleSave}>
+                        <S.ModalButtonText>저장</S.ModalButtonText>
+                      </S.ModalButton>
+                      <S.ModalButton onPress={onClose} status="warning">
+                        <S.ModalButtonText>취소</S.ModalButtonText>
+                      </S.ModalButton>
+                      {initialData && (
+                        <S.ModalButton onPress={handleDelete} status="error">
+                          <S.ModalButtonText>삭제</S.ModalButtonText>
+                        </S.ModalButton>
+                      )}
+                    </S.ButtonContainer>
+                    <TagModal
+                      isVisible={tagModalVisible}
+                      onClose={() => setTagModalVisible(false)}
+                      onSave={handleTagsUpdate}
+                      initialTags={initialData?.tags}
+                      presetTags={presetTags}
+                    />
+                  </S.ModalViewInner>
+                </S.ModalScrollView>
+              </S.ModalView>
+            </TouchableWithoutFeedback>
+          </S.Container>
         </SafeAreaView>
       </S.ModalOverlay>
     </Modal>

--- a/src/screens/RegisterScreen/LoginScreen.style.tsx
+++ b/src/screens/RegisterScreen/LoginScreen.style.tsx
@@ -1,6 +1,9 @@
 import styled from '@emotion/native';
 
 const S = {
+  Container: styled.KeyboardAvoidingView`
+    flex: 1;
+  `,
   LoginPageContainer: styled.ScrollView`
     flex: 1;
     background-color: white;

--- a/src/screens/RegisterScreen/LoginScreen.tsx
+++ b/src/screens/RegisterScreen/LoginScreen.tsx
@@ -1,6 +1,6 @@
 import {NavigationProp, useNavigation} from '@react-navigation/native';
 import React from 'react';
-import {Platform} from 'react-native';
+import {Platform, Keyboard, TouchableWithoutFeedback} from 'react-native';
 
 import {RootStackParamList} from '@/types/StackNavigationType';
 
@@ -21,46 +21,50 @@ const LoginScreen = () => {
   const {loginWithOAuth} = useProfile();
 
   return (
-    <S.LoginPageContainer>
-      <S.MomChanPickLogoWrapper>
-        <MomChanPickLogo width={160} height={160} />
-      </S.MomChanPickLogoWrapper>
-      <CredentialLogin />
+    <S.Container behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
+      <TouchableWithoutFeedback>
+        <S.LoginPageContainer>
+          <S.MomChanPickLogoWrapper>
+            <MomChanPickLogo width={160} height={160} />
+          </S.MomChanPickLogoWrapper>
+          <CredentialLogin />
 
-      <S.SocialLoginText>{'소셜 로그인'}</S.SocialLoginText>
+          <S.SocialLoginText>{'소셜 로그인'}</S.SocialLoginText>
 
-      <S.LoginButtonContainer>
-        <S.LoginButtonWrapper
-          onPress={async () => {
-            const res = await loginWithOAuth('KAKAO');
-            if (res) {
-              navigation.navigate('Home', {screen: 'Order'});
-            }
-          }}>
-          <KakaoLoginButton />
-        </S.LoginButtonWrapper>
-        <S.LoginButtonWrapper
-          onPress={async () => {
-            const res = await loginWithOAuth('NAVER');
-            if (res) {
-              navigation.navigate('Home', {screen: 'Order'});
-            }
-          }}>
-          <NaverLoginButton />
-        </S.LoginButtonWrapper>
-        {Platform.OS === 'ios' && (
-          <S.LoginButtonWrapper
-            onPress={async () => {
-              const res = await loginWithOAuth('APPLE');
-              if (res) {
-                navigation.navigate('Home', {screen: 'Order'});
-              }
-            }}>
-            <AppleLoginButton />
-          </S.LoginButtonWrapper>
-        )}
-      </S.LoginButtonContainer>
-    </S.LoginPageContainer>
+          <S.LoginButtonContainer>
+            <S.LoginButtonWrapper
+              onPress={async () => {
+                const res = await loginWithOAuth('KAKAO');
+                if (res) {
+                  navigation.navigate('Home', {screen: 'Order'});
+                }
+              }}>
+              <KakaoLoginButton />
+            </S.LoginButtonWrapper>
+            <S.LoginButtonWrapper
+              onPress={async () => {
+                const res = await loginWithOAuth('NAVER');
+                if (res) {
+                  navigation.navigate('Home', {screen: 'Order'});
+                }
+              }}>
+              <NaverLoginButton />
+            </S.LoginButtonWrapper>
+            {Platform.OS === 'ios' && (
+              <S.LoginButtonWrapper
+                onPress={async () => {
+                  const res = await loginWithOAuth('APPLE');
+                  if (res) {
+                    navigation.navigate('Home', {screen: 'Order'});
+                  }
+                }}>
+                <AppleLoginButton />
+              </S.LoginButtonWrapper>
+            )}
+          </S.LoginButtonContainer>
+        </S.LoginPageContainer>
+      </TouchableWithoutFeedback>
+    </S.Container>
   );
 };
 

--- a/src/screens/RegisterScreen/LoginScreen.tsx
+++ b/src/screens/RegisterScreen/LoginScreen.tsx
@@ -22,7 +22,7 @@ const LoginScreen = () => {
 
   return (
     <S.Container behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
-      <TouchableWithoutFeedback>
+      <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
         <S.LoginPageContainer>
           <S.MomChanPickLogoWrapper>
             <MomChanPickLogo width={160} height={160} />

--- a/src/screens/ReviewReplyScreen/ReviewReplyScreen.style.tsx
+++ b/src/screens/ReviewReplyScreen/ReviewReplyScreen.style.tsx
@@ -40,6 +40,9 @@ const S = {
   `,
 
   ReplySection: styled.View`
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
     margin-top: 16px;
     padding-top: 16px;
     border-top-width: 1px;

--- a/src/screens/ReviewReplyScreen/ReviewReplyScreen.style.tsx
+++ b/src/screens/ReviewReplyScreen/ReviewReplyScreen.style.tsx
@@ -1,7 +1,11 @@
 import styled from '@emotion/native';
 
 const S = {
-  Container: styled.ScrollView`
+  Container: styled.KeyboardAvoidingView`
+    flex: 1;
+  `,
+
+  ScreenWrapper: styled.ScrollView`
     flex: 1;
     background-color: white;
     padding: 16px;

--- a/src/screens/ReviewReplyScreen/index.tsx
+++ b/src/screens/ReviewReplyScreen/index.tsx
@@ -6,6 +6,7 @@ import S from './ReviewReplyScreen.style';
 import {ActivityIndicator} from 'react-native-paper';
 import {useNavigation} from '@react-navigation/native';
 import CustomTextInput from '@/components/common/CustomTextInput';
+import {Keyboard, TouchableWithoutFeedback, Platform} from 'react-native';
 
 type ReviewReplyScreenProps = StackScreenProps<
   ReviewStackParamList,
@@ -33,56 +34,63 @@ const ReviewReplyScreen = ({route}: ReviewReplyScreenProps) => {
   };
 
   return (
-    <S.Container>
-      <S.Title>{reviewData.name}</S.Title>
-      <S.ContentText>{reviewData.content}</S.ContentText>
-      <S.InfoText>평점: {reviewData.rating}</S.InfoText>
-      <S.InfoText>
-        작성일: {new Date(reviewData.createdAt).toLocaleDateString()}
-      </S.InfoText>
-      <S.InfoText>메뉴: {reviewData.products.join(', ')}</S.InfoText>
-
-      {reviewData.imageUrls && reviewData.imageUrls.length > 0 && (
-        <S.ImageContainer>
-          {reviewData.imageUrls.map((url, idx) => (
-            <S.StyledImage
-              key={idx.toString()}
-              source={{uri: url}}
-              resizeMode="cover"
-            />
-          ))}
-        </S.ImageContainer>
-      )}
-
-      {reviewData.reviewReplies && (
-        <S.ReplySection>
-          <S.InfoText>대댓글</S.InfoText>
-          <S.ContentText>{reviewData.reviewReplies.content}</S.ContentText>
+    <S.Container
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      keyboardVerticalOffset={Platform.OS === 'ios' ? 100 : 0}>
+      <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+        <S.ScreenWrapper>
+          <S.Title>{reviewData.name}</S.Title>
+          <S.ContentText>{reviewData.content}</S.ContentText>
+          <S.InfoText>평점: {reviewData.rating}</S.InfoText>
           <S.InfoText>
-            작성일:{' '}
-            {new Date(reviewData.createdAt).toLocaleDateString('ko-KR', {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-            })}
+            작성일: {new Date(reviewData.createdAt).toLocaleDateString()}
           </S.InfoText>
-        </S.ReplySection>
-      )}
+          <S.InfoText>메뉴: {reviewData.products.join(', ')}</S.InfoText>
 
-      <S.ReplySection>
-        <CustomTextInput
-          placeholder="리뷰에 답변해주세요!"
-          value={replyContent}
-          onChangeText={setReplyContent}
-        />
-        <S.ReplyButton onPress={handleReplySubmit} disabled={isPending}>
-          {isPending ? (
-            <ActivityIndicator animating={true} size="large" />
-          ) : (
-            <S.ReplyButtonText>대댓글 작성하기</S.ReplyButtonText>
+          {reviewData.imageUrls && reviewData.imageUrls.length > 0 && (
+            <S.ImageContainer>
+              {reviewData.imageUrls.map((url, idx) => (
+                <S.StyledImage
+                  key={idx.toString()}
+                  source={{uri: url}}
+                  resizeMode="cover"
+                />
+              ))}
+            </S.ImageContainer>
           )}
-        </S.ReplyButton>
-      </S.ReplySection>
+
+          {reviewData.reviewReplies && (
+            <S.ReplySection>
+              <S.InfoText>대댓글</S.InfoText>
+              <S.ContentText>{reviewData.reviewReplies.content}</S.ContentText>
+              <S.InfoText>
+                작성일:{' '}
+                {new Date(reviewData.createdAt).toLocaleDateString('ko-KR', {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                })}
+              </S.InfoText>
+            </S.ReplySection>
+          )}
+
+          <S.ReplySection>
+            <CustomTextInput
+              placeholder="리뷰에 답변해주세요!"
+              value={replyContent}
+              onChangeText={setReplyContent}
+              style={{height: 160, width: '100%'}}
+            />
+            <S.ReplyButton onPress={handleReplySubmit} disabled={isPending}>
+              {isPending ? (
+                <ActivityIndicator animating={true} size="large" />
+              ) : (
+                <S.ReplyButtonText>대댓글 작성하기</S.ReplyButtonText>
+              )}
+            </S.ReplyButton>
+          </S.ReplySection>
+        </S.ScreenWrapper>
+      </TouchableWithoutFeedback>
     </S.Container>
   );
 };

--- a/src/screens/ReviewReplyScreen/index.tsx
+++ b/src/screens/ReviewReplyScreen/index.tsx
@@ -73,6 +73,7 @@ const ReviewReplyScreen = ({route}: ReviewReplyScreenProps) => {
           )}
 
           <S.ReplySection>
+            {/* TODO: Input 태그 height 증가 */}
             <TextInput
               placeholder="리뷰에 답변해주세요!"
               value={replyContent}

--- a/src/screens/ReviewReplyScreen/index.tsx
+++ b/src/screens/ReviewReplyScreen/index.tsx
@@ -5,8 +5,8 @@ import {useCreateReviewReply} from '@/apis/reviews';
 import S from './ReviewReplyScreen.style';
 import {ActivityIndicator} from 'react-native-paper';
 import {useNavigation} from '@react-navigation/native';
-import CustomTextInput from '@/components/common/CustomTextInput';
 import {Keyboard, TouchableWithoutFeedback, Platform} from 'react-native';
+import TextInput from '@/components/common/TextInput/TextInput';
 
 type ReviewReplyScreenProps = StackScreenProps<
   ReviewStackParamList,
@@ -73,11 +73,10 @@ const ReviewReplyScreen = ({route}: ReviewReplyScreenProps) => {
           )}
 
           <S.ReplySection>
-            <CustomTextInput
+            <TextInput
               placeholder="리뷰에 답변해주세요!"
               value={replyContent}
               onChangeText={setReplyContent}
-              style={{height: 160, width: '100%'}}
             />
             <S.ReplyButton onPress={handleReplySubmit} disabled={isPending}>
               {isPending ? (

--- a/src/screens/ReviewReplyScreen/index.tsx
+++ b/src/screens/ReviewReplyScreen/index.tsx
@@ -34,9 +34,7 @@ const ReviewReplyScreen = ({route}: ReviewReplyScreenProps) => {
   };
 
   return (
-    <S.Container
-      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-      keyboardVerticalOffset={Platform.OS === 'ios' ? 100 : 0}>
+    <S.Container behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
       <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
         <S.ScreenWrapper>
           <S.Title>{reviewData.name}</S.Title>


### PR DESCRIPTION
**##** #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->

## 📝작업 내용
인풋 사용 페이지 키보드 가림 방지 로직 적용
- 메뉴 관리 모달
- credential 회원가입
- 로그인 화면

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷 (선택)

![Simulator Screen Recording - iPhone 16 Pro - 2025-07-10 at 18 51 11](https://github.com/user-attachments/assets/ef8bb43e-7598-43d6-984e-91fd214ac784)

![Simulator Screen Recording - iPhone 16 Pro - 2025-07-10 at 18 50 14](https://github.com/user-attachments/assets/c605a06e-c926-4c26-a23f-240820a7bc98)

의미있게 로직 사용되는 스크린 gif로 올립니다.
키보드가 늦게 뜨는건 cmd+k를 눌러주어야해서 그렇습니다..
## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

가게 관리 스크린에서 한 줄 소개는 키보드에 방해 받을 위치가 아닌 것 같아 굳이 해당 pr 로직 추가하지 않았습니다.


<img src="https://github.com/user-attachments/assets/6dfca794-65aa-415a-9436-05ea1208ea9d" width="300"/>

review-reply-screen에서 현재 피알 기준 화면 캡처입니다.
리뷰가 길어질 시 Input 태그 height가 증가하지 않아서 ux 이슈가 있을 것 같아 TODO로만 남겼습니다!


