### PR TITLE
feat: 일괄 할인 기능 적용

### DIFF
--- a/src/apis/discount/client.ts
+++ b/src/apis/discount/client.ts
@@ -1,0 +1,60 @@
+import apiClient from '../ApiClient';
+import {
+  CreateDiscountReservation,
+  DiscountReservation,
+  UpdateDiscountReservation,
+} from './model';
+
+/**
+ * GET /owner/products/discount/reservations/{marketId}
+ * 가게에 관련된 상품 할인 예약 조회
+ */
+export const getDiscountReservations = async (
+  marketId: number,
+): Promise<DiscountReservation[]> => {
+  const response = await apiClient.get<DiscountReservation[]>(
+    `/owner/products/discount/reservations/${marketId}`,
+  );
+  return response;
+};
+
+/**
+ * POST /owner/products/discount/reservations
+ * 상품리스트 할인 예약 생성
+ */
+export const createDiscountReservation = async (
+  data: CreateDiscountReservation,
+): Promise<string> => {
+  const response = await apiClient.post<string>(
+    '/owner/products/discount/reservations',
+    data,
+  );
+  return response;
+};
+
+/**
+ * PATCH /owner/products/discount/reservations
+ * 상품리스트 할인 예약 수정
+ */
+export const updateDiscountReservation = async (
+  data: UpdateDiscountReservation,
+): Promise<string> => {
+  const response = await apiClient.patch<string>(
+    '/owner/products/discount/reservations',
+    data,
+  );
+  return response;
+};
+
+/**
+ * DELETE /owner/products/discount/reservations/{discountReservationId}
+ * 상품리스트 할인 예약 삭제
+ */
+export const deleteDiscountReservation = async (
+  discountReservationId: number,
+): Promise<string> => {
+  const response = await apiClient.del<string>(
+    `/owner/products/discount/reservations/${discountReservationId}`,
+  );
+  return response;
+};

--- a/src/apis/discount/client.ts
+++ b/src/apis/discount/client.ts
@@ -1,4 +1,5 @@
 import apiClient from '../ApiClient';
+import CustomError from '../CustomError';
 import {
   CreateDiscountReservation,
   DiscountReservation,
@@ -11,11 +12,16 @@ import {
  */
 export const getDiscountReservations = async (
   marketId: number,
-): Promise<DiscountReservation[]> => {
-  const response = await apiClient.get<DiscountReservation[]>(
-    `/owner/products/discount/reservations/${marketId}`,
-  );
-  return response;
+): Promise<DiscountReservation[] | null> => {
+  try {
+    const res = await apiClient.get<DiscountReservation[] | null>(
+      `/owner/products/discount/reservations/${marketId}`,
+    );
+    return res;
+  } catch (error) {
+    console.error('할인 예약 조회 에러', error);
+    throw new CustomError(error);
+  }
 };
 
 /**
@@ -24,12 +30,17 @@ export const getDiscountReservations = async (
  */
 export const createDiscountReservation = async (
   data: CreateDiscountReservation,
-): Promise<string> => {
-  const response = await apiClient.post<string>(
-    '/owner/products/discount/reservations',
-    data,
-  );
-  return response;
+): Promise<boolean> => {
+  try {
+    const res = await apiClient.post<{code: number; message: string}>(
+      '/owner/products/discount/reservations',
+      data,
+    );
+    return !!res && res.code === 200;
+  } catch (error) {
+    console.error('할인 예약 생성 에러', error);
+    throw new CustomError(error);
+  }
 };
 
 /**
@@ -38,12 +49,17 @@ export const createDiscountReservation = async (
  */
 export const updateDiscountReservation = async (
   data: UpdateDiscountReservation,
-): Promise<string> => {
-  const response = await apiClient.patch<string>(
-    '/owner/products/discount/reservations',
-    data,
-  );
-  return response;
+): Promise<boolean> => {
+  try {
+    const res = await apiClient.patch<{code: number; message: string}>(
+      '/owner/products/discount/reservations',
+      data,
+    );
+    return !!res && res.code === 200;
+  } catch (error) {
+    console.error('할인 예약 수정 에러', error);
+    throw new CustomError(error);
+  }
 };
 
 /**
@@ -52,9 +68,14 @@ export const updateDiscountReservation = async (
  */
 export const deleteDiscountReservation = async (
   discountReservationId: number,
-): Promise<string> => {
-  const response = await apiClient.del<string>(
-    `/owner/products/discount/reservations/${discountReservationId}`,
-  );
-  return response;
+): Promise<boolean> => {
+  try {
+    const res = await apiClient.del<{code: number; message: string}>(
+      `/owner/products/discount/reservations/${discountReservationId}`,
+    );
+    return !!res && res.code === 200;
+  } catch (error) {
+    console.error('할인 예약 삭제 에러', error);
+    throw new CustomError(error);
+  }
 };

--- a/src/apis/discount/model.ts
+++ b/src/apis/discount/model.ts
@@ -1,0 +1,23 @@
+export type DiscountReservation = {
+  discountReservationId: number;
+  productIds: number[];
+  discountRate: number;
+  startAt: string;
+  endAt: string;
+};
+
+export type CreateDiscountReservation = {
+  marketId: number;
+  productIds: number[];
+  discountRate: number;
+  startAt: string;
+  endAt: string;
+};
+
+export type UpdateDiscountReservation = {
+  discountReservationId: number;
+  productIds: number[];
+  discountRate: number;
+  startAt: string;
+  endAt: string;
+};

--- a/src/apis/discount/model.ts
+++ b/src/apis/discount/model.ts
@@ -1,6 +1,8 @@
+import {MenuType} from '@/types/ProductType';
+
 export type DiscountReservation = {
   discountReservationId: number;
-  productIds: number[];
+  products: MenuType[];
   discountRate: number;
   startAt: string;
   endAt: string;

--- a/src/apis/discount/query.ts
+++ b/src/apis/discount/query.ts
@@ -23,7 +23,9 @@ export const useDiscountReservations = () => {
   });
 
   const invalidateQueries = () => {
-    queryClient.invalidateQueries({queryKey: [...QUERY_KEY, profile?.marketId]});
+    queryClient.invalidateQueries({
+      queryKey: [...QUERY_KEY, profile?.marketId],
+    });
   };
 
   const createMutation = useMutation({

--- a/src/apis/discount/query.ts
+++ b/src/apis/discount/query.ts
@@ -1,0 +1,54 @@
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+
+import useProfile from '@/hooks/useProfile';
+
+import {
+  createDiscountReservation,
+  deleteDiscountReservation,
+  getDiscountReservations,
+  updateDiscountReservation,
+} from './client';
+import {CreateDiscountReservation, UpdateDiscountReservation} from './model';
+
+const QUERY_KEY = ['discountReservations'];
+
+export const useDiscountReservations = () => {
+  const {profile} = useProfile();
+  const queryClient = useQueryClient();
+
+  const {data: reservations = [], ...queryResult} = useQuery({
+    queryKey: [...QUERY_KEY, profile?.marketId],
+    queryFn: () => getDiscountReservations(profile?.marketId!),
+    enabled: !!profile?.marketId,
+  });
+
+  const invalidateQueries = () => {
+    queryClient.invalidateQueries({queryKey: [...QUERY_KEY, profile?.marketId]});
+  };
+
+  const createMutation = useMutation({
+    mutationFn: (data: Omit<CreateDiscountReservation, 'marketId'>) =>
+      createDiscountReservation({marketId: profile?.marketId!, ...data}),
+    onSuccess: invalidateQueries,
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (data: UpdateDiscountReservation) =>
+      updateDiscountReservation(data),
+    onSuccess: invalidateQueries,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (discountReservationId: number) =>
+      deleteDiscountReservation(discountReservationId),
+    onSuccess: invalidateQueries,
+  });
+
+  return {
+    reservations,
+    ...queryResult,
+    createReservation: createMutation.mutateAsync,
+    updateReservation: updateMutation.mutateAsync,
+    deleteReservation: deleteMutation.mutateAsync,
+  };
+};

--- a/src/components/common/TabBar.tsx
+++ b/src/components/common/TabBar.tsx
@@ -28,7 +28,7 @@ type TabBarComponentType = {
   };
 };
 const tabBarData: TabBarComponentType = {
-  MenuManage: {
+  Menu: {
     label: '메뉴 관리',
     icon: {
       family: 'Feather',

--- a/src/components/discount/DiscountReservationModal.style.tsx
+++ b/src/components/discount/DiscountReservationModal.style.tsx
@@ -7,6 +7,10 @@ const S = {
     align-items: center;
     background-color: rgba(0, 0, 0, 0.5);
   `,
+  SafeArea: styled.SafeAreaView`
+    flex: 1;
+    width: 100%;
+  `,
   Container: styled.KeyboardAvoidingView`
     flex: 1;
     justify-content: center;
@@ -22,23 +26,22 @@ const S = {
     align-items: center;
   `,
   ModalTitle: styled.Text`
-    font-size: 20px;
-    font-weight: bold;
+    ${({theme}) => theme.fonts.h6}
+    font-weight: 600;
     margin-bottom: 20px;
   `,
   InputRow: styled.View`
     width: 100%;
-    margin-bottom: 15px;
+    margin-bottom: 12px;
   `,
   InputLabel: styled.Text`
-    font-size: 16px;
-    margin-bottom: 5px;
+    ${({theme}) => theme.fonts.subtitle1}
+    margin-bottom: 4px;
   `,
   ProductListContainer: styled.ScrollView`
     width: 100%;
-    max-height: 200px;
     border: 1px solid ${({theme}) => theme.colors.tertiaryHover};
-    border-radius: 5px;
+    border-radius: 8px;
   `,
   ProductItem: styled.TouchableOpacity<{
     isSelected: boolean;
@@ -53,7 +56,7 @@ const S = {
           : 'white'};
   `,
   ProductItemText: styled.Text<{disabled: boolean}>`
-    ${({theme}) => theme.fonts.body1}
+    ${({theme}) => theme.fonts.body2}
     color: ${({disabled, theme}) =>
       disabled ? theme.colors.disabled : theme.colors.dark};
   `,
@@ -66,7 +69,7 @@ const S = {
   ModalButton: styled.TouchableOpacity<{status?: 'warning' | 'error'}>`
     flex: 1;
     padding: 10px;
-    border-radius: 6px;
+    border-radius: 8px;
     align-items: center;
     margin: 0 5px;
     background-color: ${({status, theme}) =>
@@ -77,8 +80,62 @@ const S = {
           : theme.colors.primary};
   `,
   ModalButtonText: styled.Text`
+    ${({theme}) => theme.fonts.body2}
     color: white;
     font-weight: bold;
+  `,
+  TimeRangeContainer: styled.View`
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+  `,
+  TimeInputTouchable: styled.TouchableOpacity`
+    flex: 1;
+    border: 1px solid ${({theme}) => theme.colors.primary};
+    border-radius: 8px;
+    padding: 12px 0;
+    background-color: white;
+  `,
+  TimeInputText: styled.Text`
+    ${({theme}) => theme.fonts.body1}
+    text-align: center;
+  `,
+  SelectedProductsContainer: styled.View`
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    width: 100%;
+    padding: 8px;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+  `,
+
+  ProductTag: styled.View`
+    border: 1px solid ${({theme}) => theme.colors.primaryLight};
+    border-radius: 16px;
+    padding: 6px 12px;
+    margin-right: 8px;
+    margin-bottom: 8px;
+    align-items: center;
+    justify-content: center;
+  `,
+
+  ProductTagText: styled.Text`
+    ${({theme}) => theme.fonts.body1}
+    color: ${({theme}) => theme.colors.primaryLight};
+    font-size: 14px;
+  `,
+
+  PlaceholderText: styled.Text`
+    color: #999;
+    font-size: 14px;
+    line-height: 24px;
+  `,
+
+  AlertText: styled.Text`
+    ${({theme}) => theme.fonts.body2}
+    color: ${({theme}) => theme.colors.error};
   `,
 };
 

--- a/src/components/discount/DiscountReservationModal.style.tsx
+++ b/src/components/discount/DiscountReservationModal.style.tsx
@@ -1,0 +1,85 @@
+import styled from '@emotion/native';
+
+const S = {
+  ModalOverlay: styled.View`
+    flex: 1;
+    justify-content: center;
+    align-items: center;
+    background-color: rgba(0, 0, 0, 0.5);
+  `,
+  Container: styled.KeyboardAvoidingView`
+    flex: 1;
+    justify-content: center;
+    align-items: center;
+  `,
+
+  ModalView: styled.View`
+    display: flex;
+    width: 90%;
+    background-color: white;
+    border-radius: 12px;
+    padding: 20px;
+    align-items: center;
+  `,
+  ModalTitle: styled.Text`
+    font-size: 20px;
+    font-weight: bold;
+    margin-bottom: 20px;
+  `,
+  InputRow: styled.View`
+    width: 100%;
+    margin-bottom: 15px;
+  `,
+  InputLabel: styled.Text`
+    font-size: 16px;
+    margin-bottom: 5px;
+  `,
+  ProductListContainer: styled.ScrollView`
+    width: 100%;
+    max-height: 200px;
+    border: 1px solid ${({theme}) => theme.colors.tertiaryHover};
+    border-radius: 5px;
+  `,
+  ProductItem: styled.TouchableOpacity<{
+    isSelected: boolean;
+    disabled: boolean;
+  }>`
+    padding: 10px;
+    background-color: ${({isSelected, disabled, theme}) =>
+      disabled
+        ? theme.colors.tertiaryHover
+        : isSelected
+          ? theme.colors.primaryLight
+          : 'white'};
+  `,
+  ProductItemText: styled.Text<{disabled: boolean}>`
+    ${({theme}) => theme.fonts.body1}
+    color: ${({disabled, theme}) =>
+      disabled ? theme.colors.disabled : theme.colors.dark};
+  `,
+  ButtonContainer: styled.View`
+    flex-direction: row;
+    justify-content: center;
+    width: 100%;
+    margin-top: 20px;
+  `,
+  ModalButton: styled.TouchableOpacity<{status?: 'warning' | 'error'}>`
+    flex: 1;
+    padding: 10px;
+    border-radius: 6px;
+    align-items: center;
+    margin: 0 5px;
+    background-color: ${({status, theme}) =>
+      status === 'error'
+        ? theme.colors.error
+        : status === 'warning'
+          ? theme.colors.tertiaryDisabled
+          : theme.colors.primary};
+  `,
+  ModalButtonText: styled.Text`
+    color: white;
+    font-weight: bold;
+  `,
+};
+
+export default S;

--- a/src/components/discount/DiscountReservationModal.tsx
+++ b/src/components/discount/DiscountReservationModal.tsx
@@ -1,10 +1,13 @@
 import React, {useState, useEffect} from 'react';
-import {Modal, Alert, Platform, SafeAreaView} from 'react-native';
+import {Modal, Alert, Platform} from 'react-native';
 import useProduct from '@/hooks/useProduct';
 import {useDiscountReservations} from '@/apis/discount/query';
 import {DiscountReservation} from '@/apis/discount/model';
 import CustomTextInput from '../common/CustomTextInput';
 import S from './DiscountReservationModal.style';
+
+import DatePicker from 'react-native-date-picker';
+import {format} from '@/utils/date';
 
 type Props = {
   isVisible: boolean;
@@ -22,6 +25,14 @@ const DiscountReservationModal = ({isVisible, onClose, initialData}: Props) => {
   const [endAt, setEndAt] = useState('');
   const [selectedProductIds, setSelectedProductIds] = useState<number[]>([]);
 
+  const [pickerVisibleFor, setPickerVisibleFor] = useState<
+    'startAt' | 'endAt' | null
+  >(null);
+
+  const selectedProducts = products.filter(p =>
+    selectedProductIds.includes(p.id),
+  );
+
   useEffect(() => {
     if (isVisible) {
       fetchProducts();
@@ -38,6 +49,16 @@ const DiscountReservationModal = ({isVisible, onClose, initialData}: Props) => {
       }
     }
   }, [initialData, isVisible, fetchProducts]);
+
+  const getPickerDefaultDate = () => {
+    const timeString = pickerVisibleFor === 'startAt' ? startAt : endAt;
+    const defaultDate = new Date();
+    if (timeString) {
+      const [hours, minutes] = timeString.split(':').map(Number);
+      defaultDate.setHours(hours, minutes, 0, 0);
+    }
+    return defaultDate;
+  };
 
   const handleToggleProduct = (productId: number, isDisabled: boolean) => {
     if (isDisabled) return;
@@ -59,7 +80,7 @@ const DiscountReservationModal = ({isVisible, onClose, initialData}: Props) => {
       !endAt ||
       selectedProductIds.length === 0
     ) {
-      Alert.alert('입력 오류', '모든 필드를 올바르게 입력해주세요.');
+      Alert.alert('입력 오류', '모든 값을 올바르게 입력해주세요.');
       return;
     }
 
@@ -112,7 +133,7 @@ const DiscountReservationModal = ({isVisible, onClose, initialData}: Props) => {
   return (
     <Modal visible={isVisible} transparent={true} animationType="slide">
       <S.ModalOverlay>
-        <SafeAreaView style={{flex: 1, width: '100%'}}>
+        <S.SafeArea>
           <S.Container behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
             <S.ModalView>
               <S.ModalTitle>
@@ -123,7 +144,6 @@ const DiscountReservationModal = ({isVisible, onClose, initialData}: Props) => {
                 <S.InputLabel>상품 선택</S.InputLabel>
                 <S.ProductListContainer>
                   {products.map(product => {
-                    // [ ✨ 수정된 부분 ✨ ]
                     const isReservedByAnother =
                       product.reservationStatus !== null;
                     const isPartOfCurrentReservation =
@@ -147,6 +167,22 @@ const DiscountReservationModal = ({isVisible, onClose, initialData}: Props) => {
                     );
                   })}
                 </S.ProductListContainer>
+                <S.AlertText>예약 할인은 상품당 1개만 가능합니다.</S.AlertText>
+              </S.InputRow>
+
+              <S.InputRow>
+                <S.InputLabel>선택된 반찬</S.InputLabel>
+                <S.SelectedProductsContainer>
+                  {selectedProducts.length > 0 ? (
+                    selectedProducts.map(product => (
+                      <S.ProductTag key={product.id}>
+                        <S.ProductTagText>{product.name}</S.ProductTagText>
+                      </S.ProductTag>
+                    ))
+                  ) : (
+                    <S.PlaceholderText>상품을 선택해주세요.</S.PlaceholderText>
+                  )}
+                </S.SelectedProductsContainer>
               </S.InputRow>
 
               <S.InputRow>
@@ -159,13 +195,18 @@ const DiscountReservationModal = ({isVisible, onClose, initialData}: Props) => {
               </S.InputRow>
 
               <S.InputRow>
-                <S.InputLabel>시작 시간 (HH:MM)</S.InputLabel>
-                <CustomTextInput value={startAt} onChangeText={setStartAt} />
-              </S.InputRow>
-
-              <S.InputRow>
-                <S.InputLabel>종료 시간 (HH:MM)</S.InputLabel>
-                <CustomTextInput value={endAt} onChangeText={setEndAt} />
+                <S.InputLabel>할인 시간</S.InputLabel>
+                <S.TimeRangeContainer>
+                  <S.TimeInputTouchable
+                    onPress={() => setPickerVisibleFor('startAt')}>
+                    <S.TimeInputText>{startAt || '시작 시간'}</S.TimeInputText>
+                  </S.TimeInputTouchable>
+                  <S.TimeInputText>~ </S.TimeInputText>
+                  <S.TimeInputTouchable
+                    onPress={() => setPickerVisibleFor('endAt')}>
+                    <S.TimeInputText>{endAt || '종료 시간'}</S.TimeInputText>
+                  </S.TimeInputTouchable>
+                </S.TimeRangeContainer>
               </S.InputRow>
 
               <S.ButtonContainer>
@@ -183,7 +224,34 @@ const DiscountReservationModal = ({isVisible, onClose, initialData}: Props) => {
               </S.ButtonContainer>
             </S.ModalView>
           </S.Container>
-        </SafeAreaView>
+
+          <DatePicker
+            modal
+            open={!!pickerVisibleFor}
+            mode="time"
+            date={getPickerDefaultDate()}
+            minuteInterval={10}
+            onConfirm={date => {
+              const formattedTime = format(date.getTime(), 'HH:mm');
+              if (pickerVisibleFor === 'startAt') {
+                setStartAt(formattedTime);
+              } else if (pickerVisibleFor === 'endAt') {
+                setEndAt(formattedTime);
+              }
+              setPickerVisibleFor(null);
+            }}
+            onCancel={() => {
+              setPickerVisibleFor(null);
+            }}
+            title={
+              pickerVisibleFor === 'startAt'
+                ? '시작 시간 선택'
+                : '종료 시간 선택'
+            }
+            confirmText="확인"
+            cancelText="취소"
+          />
+        </S.SafeArea>
       </S.ModalOverlay>
     </Modal>
   );

--- a/src/components/discount/DiscountReservationModal.tsx
+++ b/src/components/discount/DiscountReservationModal.tsx
@@ -1,0 +1,192 @@
+import React, {useState, useEffect} from 'react';
+import {Modal, Alert, Platform, SafeAreaView} from 'react-native';
+import useProduct from '@/hooks/useProduct';
+import {useDiscountReservations} from '@/apis/discount/query';
+import {DiscountReservation} from '@/apis/discount/model';
+import CustomTextInput from '../common/CustomTextInput';
+import S from './DiscountReservationModal.style';
+
+type Props = {
+  isVisible: boolean;
+  onClose: () => void;
+  initialData: DiscountReservation | null;
+};
+
+const DiscountReservationModal = ({isVisible, onClose, initialData}: Props) => {
+  const {products, fetch: fetchProducts} = useProduct();
+  const {createReservation, updateReservation, deleteReservation} =
+    useDiscountReservations();
+
+  const [discountRate, setDiscountRate] = useState('');
+  const [startAt, setStartAt] = useState('');
+  const [endAt, setEndAt] = useState('');
+  const [selectedProductIds, setSelectedProductIds] = useState<number[]>([]);
+
+  useEffect(() => {
+    if (isVisible) {
+      fetchProducts();
+      if (initialData) {
+        setDiscountRate(initialData.discountRate.toString());
+        setStartAt(initialData.startAt);
+        setEndAt(initialData.endAt);
+        setSelectedProductIds(initialData.products.map(p => p.id));
+      } else {
+        setDiscountRate('');
+        setStartAt('');
+        setEndAt('');
+        setSelectedProductIds([]);
+      }
+    }
+  }, [initialData, isVisible, fetchProducts]);
+
+  const handleToggleProduct = (productId: number, isDisabled: boolean) => {
+    if (isDisabled) return;
+
+    setSelectedProductIds(prev =>
+      prev.includes(productId)
+        ? prev.filter(id => id !== productId)
+        : [...prev, productId],
+    );
+  };
+
+  const handleSave = async () => {
+    const rate = parseInt(discountRate, 10);
+    if (
+      !rate ||
+      rate <= 0 ||
+      rate > 100 ||
+      !startAt ||
+      !endAt ||
+      selectedProductIds.length === 0
+    ) {
+      Alert.alert('입력 오류', '모든 필드를 올바르게 입력해주세요.');
+      return;
+    }
+
+    try {
+      if (initialData) {
+        await updateReservation({
+          discountReservationId: initialData.discountReservationId,
+          productIds: selectedProductIds,
+          discountRate: rate,
+          startAt,
+          endAt,
+        });
+        Alert.alert('성공', '예약 할인이 수정되었습니다.');
+      } else {
+        await createReservation({
+          productIds: selectedProductIds,
+          discountRate: rate,
+          startAt,
+          endAt,
+        });
+        Alert.alert('성공', '새로운 예약 할인이 생성되었습니다.');
+      }
+      onClose();
+    } catch (e) {
+      Alert.alert('오류', '저장에 실패했습니다.');
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!initialData) return;
+
+    Alert.alert('삭제 확인', '정말로 이 예약을 삭제하시겠습니까?', [
+      {text: '취소', style: 'cancel'},
+      {
+        text: '삭제',
+        style: 'destructive',
+        onPress: async () => {
+          try {
+            await deleteReservation(initialData.discountReservationId);
+            Alert.alert('성공', '예약이 삭제되었습니다.');
+            onClose();
+          } catch (e) {
+            Alert.alert('오류', '삭제에 실패했습니다.');
+          }
+        },
+      },
+    ]);
+  };
+
+  return (
+    <Modal visible={isVisible} transparent={true} animationType="slide">
+      <S.ModalOverlay>
+        <SafeAreaView style={{flex: 1, width: '100%'}}>
+          <S.Container behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
+            <S.ModalView>
+              <S.ModalTitle>
+                {initialData ? '예약 할인 수정' : '새 예약 할인'}
+              </S.ModalTitle>
+
+              <S.InputRow>
+                <S.InputLabel>상품 선택</S.InputLabel>
+                <S.ProductListContainer>
+                  {products.map(product => {
+                    // [ ✨ 수정된 부분 ✨ ]
+                    const isReservedByAnother =
+                      product.reservationStatus !== null;
+                    const isPartOfCurrentReservation =
+                      initialData?.products.some(p => p.id === product.id) ??
+                      false;
+                    const isDisabled =
+                      isReservedByAnother && !isPartOfCurrentReservation;
+
+                    return (
+                      <S.ProductItem
+                        key={product.id}
+                        onPress={() =>
+                          handleToggleProduct(product.id, isDisabled)
+                        }
+                        isSelected={selectedProductIds.includes(product.id)}
+                        disabled={isDisabled}>
+                        <S.ProductItemText disabled={isDisabled}>
+                          {product.name}
+                        </S.ProductItemText>
+                      </S.ProductItem>
+                    );
+                  })}
+                </S.ProductListContainer>
+              </S.InputRow>
+
+              <S.InputRow>
+                <S.InputLabel>할인율 (%)</S.InputLabel>
+                <CustomTextInput
+                  value={discountRate}
+                  onChangeText={setDiscountRate}
+                  keyboardType="number-pad"
+                />
+              </S.InputRow>
+
+              <S.InputRow>
+                <S.InputLabel>시작 시간 (HH:MM)</S.InputLabel>
+                <CustomTextInput value={startAt} onChangeText={setStartAt} />
+              </S.InputRow>
+
+              <S.InputRow>
+                <S.InputLabel>종료 시간 (HH:MM)</S.InputLabel>
+                <CustomTextInput value={endAt} onChangeText={setEndAt} />
+              </S.InputRow>
+
+              <S.ButtonContainer>
+                <S.ModalButton onPress={handleSave}>
+                  <S.ModalButtonText>저장</S.ModalButtonText>
+                </S.ModalButton>
+                <S.ModalButton onPress={onClose} status="warning">
+                  <S.ModalButtonText>취소</S.ModalButtonText>
+                </S.ModalButton>
+                {initialData && (
+                  <S.ModalButton onPress={handleDelete} status="error">
+                    <S.ModalButtonText>삭제</S.ModalButtonText>
+                  </S.ModalButton>
+                )}
+              </S.ButtonContainer>
+            </S.ModalView>
+          </S.Container>
+        </SafeAreaView>
+      </S.ModalOverlay>
+    </Modal>
+  );
+};
+
+export default DiscountReservationModal;

--- a/src/components/menu/Menu.style.tsx
+++ b/src/components/menu/Menu.style.tsx
@@ -1,35 +1,56 @@
 import styled from '@emotion/native';
+import {MenuType} from '@/types/ProductType';
 
 const S = {
   MenuWrapper: styled.View`
     background-color: white;
     display: flex;
     flex-direction: row;
+    border: 1.2px solid ${({theme}) => theme.colors.primary};
+    border-radius: 20px;
     align-items: center;
-    margin: 4px 20px;
+    margin: 6px 20px;
     padding: 12px;
+    shadow-color: ${({theme}) => theme.colors.tertiary};
+    shadow-opacity: 0.04;
+    shadow-radius: 8px;
+    shadow-offset: 0px 1px;
+    elevation: 2;
+  `,
+
+  Col: styled.View`
+    display: flex;
+    flex; 1:
+    flex-direction: column;
+  `,
+
+  Row: styled.View`
+    display: flex;
+    flex: 1;
+    flex-direction: row;
   `,
   MenuImage: styled.Image`
-    width: 60px;
-    height: 60px;
-    margin-right: 24px;
+    width: 88px;
+    height: 88px;
+    margin-right: 16px;
     border-radius: 16px;
   `,
   MenuInfoWrapper: styled.View`
     display: flex;
     flex-direction: column;
     flex: 1;
+    gap: 4px;
   `,
   MenuNameText: styled.Text`
+    ${props => props.theme.fonts.body1};
     font-size: 16px;
     font-weight: bold;
-    margin-bottom: 4px;
   `,
   DicountInfoWrapper: styled.View`
     display: flex;
     flex-direction: row;
+    align-items: center;
     gap: 8px;
-    margin: 2px 0px;
   `,
   DiscountRateText: styled.Text`
     color: red;
@@ -47,11 +68,41 @@ const S = {
   CurrentInfoWrapper: styled.View`
     display: flex;
     flex-direction: row;
+    align-items: center;
     gap: 8px;
-    margin: 2px 0px;
+  `,
+
+  StatusBorder: styled.View<{status: MenuType['reservationStatus']}>`
+    position: absolute;
+    top: 10px;
+    right: 10px;
+
+    flex-direction: row;
+    align-items: center;
+    border-radius: 10px;
+    padding: 2px 6px;
+
+    ${({theme, status}) =>
+      status === 'ACTIVE'
+        ? `border: 1px solid ${theme.colors.primary};`
+        : status === 'PENDING'
+          ? `border: 1px solid ${theme.colors.warning};`
+          : `border: none;`}
   `,
   CurrentStatusText: styled.Text`
     color: ${props => props.theme.colors.primary};
+  `,
+
+  CurrentDiscountStatusText: styled.Text<{
+    status: MenuType['reservationStatus'];
+  }>`
+    ${({theme, status}) =>
+      status === 'ACTIVE'
+        ? `color: ${theme.colors.primary};`
+        : status === 'PENDING'
+          ? `color: ${theme.colors.warning};`
+          : `color: transparent;`}
+    ${({theme}) => theme.fonts.subtitle2}
   `,
   MenuCounter: styled.View`
     display: flex;

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -14,13 +14,35 @@ const statusMap: Record<MenuType['productStatus'], string> = {
   OUT_OF_STOCK: '품절',
   HIDDEN: '숨김',
 };
+
+const discountStatusMap: Record<
+  NonNullable<MenuType['reservationStatus']>,
+  string
+> = {
+  ACTIVE: '일괄 할인 중',
+  PENDING: '할인 예약',
+};
+
 const Menu = ({menu, onEdit, onIncreaseStock, onDecreaseStock}: Props) => {
   const isOutOfStock = menu.stock === 0;
+  const discountStatus = menu.reservationStatus
+    ? discountStatusMap[menu.reservationStatus]
+    : '';
   return (
     <S.MenuWrapper>
       <S.MenuImage source={{uri: menu.image}} />
+      {menu.reservationStatus && (
+        <S.StatusBorder status={menu.reservationStatus}>
+          <S.CurrentDiscountStatusText status={menu.reservationStatus}>
+            {discountStatus}
+          </S.CurrentDiscountStatusText>
+        </S.StatusBorder>
+      )}
       <S.MenuInfoWrapper>
-        <S.MenuNameText>{menu.name}</S.MenuNameText>
+        <S.MenuNameText numberOfLines={1} ellipsizeMode="tail">
+          {menu.name.length > 8 ? menu.name.slice(0, 8) + '...' : menu.name}
+        </S.MenuNameText>
+
         <S.DicountInfoWrapper>
           <S.DiscountRateText>{menu.discountRate} %</S.DiscountRateText>
           <S.OriginPriceText>

--- a/src/components/menu/MenuModal.tsx
+++ b/src/components/menu/MenuModal.tsx
@@ -59,6 +59,7 @@ const MenuModal = ({
     discountPrice: 0,
     stock: 0,
     productStatus: 'HIDDEN',
+    reservationStatus: 'PENDING',
     tags: [],
   });
 
@@ -81,6 +82,7 @@ const MenuModal = ({
           discountPrice: 0,
           stock: 0,
           productStatus: 'HIDDEN',
+          reservationStatus: 'PENDING',
           tags: [],
         });
       }
@@ -262,6 +264,7 @@ const MenuModal = ({
                         onChangeText={text =>
                           handleInputChange('originPrice', text)
                         }
+                        disabled={menuData.reservationStatus === 'ACTIVE'}
                       />
                     </S.InputRow>
                     <S.InputRow>
@@ -271,6 +274,7 @@ const MenuModal = ({
                         onChangeText={text =>
                           handleInputChange('discountPrice', text)
                         }
+                        disabled={menuData.reservationStatus === 'ACTIVE'}
                       />
                     </S.InputRow>
 

--- a/src/components/menu/MenuModal.tsx
+++ b/src/components/menu/MenuModal.tsx
@@ -264,7 +264,7 @@ const MenuModal = ({
                         onChangeText={text =>
                           handleInputChange('originPrice', text)
                         }
-                        disabled={menuData.reservationStatus === 'ACTIVE'}
+                        disabled={menuData.reservationStatus != null}
                       />
                     </S.InputRow>
                     <S.InputRow>
@@ -274,7 +274,7 @@ const MenuModal = ({
                         onChangeText={text =>
                           handleInputChange('discountPrice', text)
                         }
-                        disabled={menuData.reservationStatus === 'ACTIVE'}
+                        disabled={menuData.reservationStatus != null}
                       />
                     </S.InputRow>
 

--- a/src/navigation/HomeNavigator.tsx
+++ b/src/navigation/HomeNavigator.tsx
@@ -13,6 +13,7 @@ import MyPageScreen from '@/screens/MyPageScreen';
 
 import {HomeStackParamList} from '@/types/StackNavigationType';
 
+import MenuNavigator from './MenuNavigator';
 import OrderNavigator from './OrderNavigator';
 import ReviewNavigator from './ReviewNavigator';
 import theme from '@/context/theme';
@@ -35,8 +36,7 @@ const marketInfoScreenOptions: BottomTabNavigationOptions = {
 };
 
 const menuManageScreenOptions: BottomTabNavigationOptions = {
-  ...defaultScreenOptions,
-  headerTitle: () => <HeaderTitle title="메뉴 관리" />,
+  headerShown: false,
 };
 
 const reviewScreenOptions: BottomTabNavigationOptions = {
@@ -62,8 +62,8 @@ const HomeNavigator = () => {
         options={marketInfoScreenOptions}
       />
       <Tab.Screen
-        name="MenuManage"
-        component={MenuManageScreen}
+        name="Menu"
+        component={MenuNavigator}
         options={menuManageScreenOptions}
       />
       <Tab.Screen

--- a/src/navigation/HomeNavigator.tsx
+++ b/src/navigation/HomeNavigator.tsx
@@ -8,7 +8,6 @@ import HeaderTitle from '@/components/common/Appbar/HeaderTitle';
 import {TabBar} from '@components/common';
 
 import MarketInfoScreen from '@/screens/MarketInfoScreen';
-import MenuManageScreen from '@/screens/MenuManageScreen';
 import MyPageScreen from '@/screens/MyPageScreen';
 
 import {HomeStackParamList} from '@/types/StackNavigationType';

--- a/src/navigation/MenuNavigator.tsx
+++ b/src/navigation/MenuNavigator.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import {
+  createStackNavigator,
+  StackNavigationOptions,
+} from '@react-navigation/stack';
+import MenuManageScreen from '@/screens/MenuManageScreen';
+import DiscountReservationScreen from '@/screens/DiscountReservationScreen';
+import {defaultOptions} from '@/components/common/Appbar/AppbarOptions';
+import {MenuStackParamList} from '@/types/StackNavigationType';
+import HeaderTitle from '@/components/common/Appbar/HeaderTitle';
+
+const Stack = createStackNavigator<MenuStackParamList>();
+
+const menuManageScreenOptions: StackNavigationOptions = {
+  ...defaultOptions,
+  headerTitle: () => <HeaderTitle title="메뉴 관리" />,
+};
+
+const menuDiscountManageScreenOptions: StackNavigationOptions = {
+  ...defaultOptions,
+  headerTitle: () => <HeaderTitle title="일괄 할인" />,
+};
+
+const MenuNavigator = () => {
+  return (
+    <Stack.Navigator
+      initialRouteName="MenuManage"
+      screenOptions={{headerShown: true}}>
+      <Stack.Screen
+        name="MenuManage"
+        component={MenuManageScreen}
+        options={menuManageScreenOptions}
+      />
+      <Stack.Screen
+        name="DiscountReservation"
+        component={DiscountReservationScreen}
+        options={menuDiscountManageScreenOptions}
+      />
+    </Stack.Navigator>
+  );
+};
+
+export default MenuNavigator;

--- a/src/screens/DiscountReservationScreen/DiscountReservationScreen.style.tsx
+++ b/src/screens/DiscountReservationScreen/DiscountReservationScreen.style.tsx
@@ -16,6 +16,10 @@ const S = {
   `,
 
   ItemContainer: styled.View`
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    gap: 8px;
     background-color: white;
     padding: 16px;
     border-radius: 8px;
@@ -25,7 +29,18 @@ const S = {
 
   ItemText: styled.Text`
     font-size: 16px;
-    margin-bottom: 8px;
+  `,
+
+  ProductList: styled.View`
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  `,
+
+  ProductListItem: styled.Text`
+    ${({theme}) => theme.fonts.body2}
+    color: ${({theme}) => theme.colors.tertiaryDisabled};
+    padding-left: 8px;
   `,
 
   EditButton: styled.TouchableOpacity`
@@ -47,6 +62,7 @@ const S = {
   `,
 
   ErrorText: styled.Text`
+    ${({theme}) => theme.fonts.subtitle1}
     text-align: center;
     margin-top: 20px;
     color: ${({theme}) => theme.colors.error};

--- a/src/screens/DiscountReservationScreen/DiscountReservationScreen.style.tsx
+++ b/src/screens/DiscountReservationScreen/DiscountReservationScreen.style.tsx
@@ -1,0 +1,56 @@
+import styled from '@emotion/native';
+
+const S = {
+  Container: styled.View`
+    flex: 1;
+    padding: 16px;
+    background-color: white;
+  `,
+
+  CreateButton: styled.TouchableOpacity`
+    background-color: ${({theme}) => theme.colors.primary};
+    padding: 12px;
+    border-radius: 8px;
+    align-items: center;
+    margin-bottom: 16px;
+  `,
+
+  ItemContainer: styled.View`
+    background-color: white;
+    padding: 16px;
+    border-radius: 8px;
+    margin-bottom: 12px;
+    border: 1px solid ${({theme}) => theme.colors.tertiaryDisabled};
+  `,
+
+  ItemText: styled.Text`
+    font-size: 16px;
+    margin-bottom: 8px;
+  `,
+
+  EditButton: styled.TouchableOpacity`
+    background-color: ${({theme}) => theme.colors.primary};
+    padding: 8px;
+    border-radius: 4px;
+    align-items: center;
+    margin-top: 8px;
+  `,
+
+  ButtonText: styled.Text`
+    color: white;
+    font-weight: bold;
+  `,
+
+  LoadingText: styled.Text`
+    text-align: center;
+    margin-top: 20px;
+  `,
+
+  ErrorText: styled.Text`
+    text-align: center;
+    margin-top: 20px;
+    color: ${({theme}) => theme.colors.error};
+  `,
+};
+
+export default S;

--- a/src/screens/DiscountReservationScreen/index.tsx
+++ b/src/screens/DiscountReservationScreen/index.tsx
@@ -1,0 +1,59 @@
+import React, {useState} from 'react';
+import {ScrollView} from 'react-native';
+import {useDiscountReservations} from '@/apis/discount/query';
+import {DiscountReservation} from '@/apis/discount/model';
+import DiscountReservationModal from '@/components/discount/DiscountReservationModal';
+import S from './DiscountReservationScreen.style';
+
+const DiscountReservationScreen = () => {
+  const {reservations, isLoading, error} = useDiscountReservations();
+  const [modalVisible, setModalVisible] = useState(false);
+  const [selectedReservation, setSelectedReservation] =
+    useState<DiscountReservation | null>(null);
+
+  const handleOpenModal = (reservation: DiscountReservation | null) => {
+    setSelectedReservation(reservation);
+    setModalVisible(true);
+  };
+
+  const handleCloseModal = () => {
+    setModalVisible(false);
+    setSelectedReservation(null);
+  };
+
+  if (isLoading || !reservations) {
+    return <S.LoadingText>로딩 중...</S.LoadingText>;
+  }
+
+  if (error) {
+    return <S.ErrorText>오류가 발생했습니다.</S.ErrorText>;
+  }
+
+  return (
+    <S.Container>
+      <ScrollView>
+        {reservations.map(item => (
+          <S.ItemContainer key={item.discountReservationId}>
+            <S.ItemText>
+              할인율: {item.discountRate}% ({item.startAt} - {item.endAt})
+            </S.ItemText>
+            <S.ItemText>적용 상품: {item.products.length}개</S.ItemText>
+            <S.EditButton onPress={() => handleOpenModal(item)}>
+              <S.ButtonText>수정</S.ButtonText>
+            </S.EditButton>
+          </S.ItemContainer>
+        ))}
+        <S.CreateButton onPress={() => handleOpenModal(null)}>
+          <S.ButtonText>예약 할인하기</S.ButtonText>
+        </S.CreateButton>
+      </ScrollView>
+      <DiscountReservationModal
+        isVisible={modalVisible}
+        onClose={handleCloseModal}
+        initialData={selectedReservation}
+      />
+    </S.Container>
+  );
+};
+
+export default DiscountReservationScreen;

--- a/src/screens/DiscountReservationScreen/index.tsx
+++ b/src/screens/DiscountReservationScreen/index.tsx
@@ -37,7 +37,16 @@ const DiscountReservationScreen = () => {
             <S.ItemText>
               할인율: {item.discountRate}% ({item.startAt} - {item.endAt})
             </S.ItemText>
-            <S.ItemText>적용 상품: {item.products.length}개</S.ItemText>
+
+            <S.ProductList>
+              <S.ItemText>적용 상품:</S.ItemText>
+              {item.products.map(product => (
+                <S.ProductListItem key={product.id}>
+                  - {product.name}
+                </S.ProductListItem>
+              ))}
+            </S.ProductList>
+
             <S.EditButton onPress={() => handleOpenModal(item)}>
               <S.ButtonText>수정</S.ButtonText>
             </S.EditButton>

--- a/src/screens/MenuManageScreen/MenuManageDetailScreen.style.tsx
+++ b/src/screens/MenuManageScreen/MenuManageDetailScreen.style.tsx
@@ -10,7 +10,9 @@ const S = {
   `,
 
   AddProductView: styled.View`
-    align-items: center;
+    flex-direction: row;
+    padding: 0px 24px;
+    justify-content: space-between;
   `,
 
   AddButton: styled(Button)`
@@ -22,15 +24,13 @@ const S = {
 
     background-color: ${({theme}) => theme.colors.primary};
 
-    padding: 4px 24px;
-    margin: 12px;
+    padding: 4px 20px;
+    margin: 8px;
   `,
 
   AddButtonText: styled(Text)`
     color: rgba(255, 255, 255, 1);
     padding: 4px 12px;
-
-    margin-left: 8px;
 
     ${({theme}) => theme.fonts.default}
   `,

--- a/src/screens/MenuManageScreen/MenuManageDetailScreen.style.tsx
+++ b/src/screens/MenuManageScreen/MenuManageDetailScreen.style.tsx
@@ -2,6 +2,15 @@ import styled from '@emotion/native';
 import {Button, Text} from 'react-native-paper';
 
 const S = {
+  Container: styled.ScrollView`
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    background-color: white;
+    width: 100%;
+    height: 100%;
+  `,
+
   MainText: styled.Text`
     font-size: 20px;
     font-style: normal;
@@ -24,15 +33,15 @@ const S = {
 
     background-color: ${({theme}) => theme.colors.primary};
 
-    padding: 4px 20px;
+    padding: 4px 12px;
     margin: 8px;
   `,
 
-  AddButtonText: styled(Text)`
+  AddButtonText: styled.Text`
     color: rgba(255, 255, 255, 1);
     padding: 4px 12px;
-
-    ${({theme}) => theme.fonts.default}
+    ${props => props.theme.fonts.subtitle2};
+    font-size: 16px;
   `,
 };
 

--- a/src/screens/MenuManageScreen/MenuManageDetailScreen.style.tsx
+++ b/src/screens/MenuManageScreen/MenuManageDetailScreen.style.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/native';
-import {Button, Text} from 'react-native-paper';
+import {Button} from 'react-native-paper';
 
 const S = {
   Container: styled.ScrollView`

--- a/src/screens/MenuManageScreen/MenuManageDetailScreen.tsx
+++ b/src/screens/MenuManageScreen/MenuManageDetailScreen.tsx
@@ -2,6 +2,8 @@ import {useNavigation} from '@react-navigation/native';
 import React, {useState} from 'react';
 import {Alert} from 'react-native';
 import {RefreshControl, ScrollView} from 'react-native-gesture-handler';
+import {RootStackParamList} from '@/types/StackNavigationType';
+import {StackNavigationProp} from '@react-navigation/stack';
 
 import Icon from 'react-native-vector-icons/Feather';
 
@@ -29,7 +31,7 @@ const MenuManageDetailScreen = ({menus, updateMenus}: Props) => {
   const [modalVisible, setModalVisible] = useState(false);
   const [currentMenu, setCurrentMenu] = useState<MenuType | null>(null);
 
-  const navigation = useNavigation();
+  const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
   const {marketInfo} = useMarket();
   const {profile} = useProfile();
   const {refresh} = useProduct();

--- a/src/screens/MenuManageScreen/MenuManageDetailScreen.tsx
+++ b/src/screens/MenuManageScreen/MenuManageDetailScreen.tsx
@@ -2,7 +2,7 @@ import {useNavigation} from '@react-navigation/native';
 import React, {useState} from 'react';
 import {Alert} from 'react-native';
 import {RefreshControl, ScrollView} from 'react-native-gesture-handler';
-import {RootStackParamList} from '@/types/StackNavigationType';
+import {MenuStackParamList} from '@/types/StackNavigationType';
 import {StackNavigationProp} from '@react-navigation/stack';
 
 import Icon from 'react-native-vector-icons/Feather';
@@ -31,7 +31,7 @@ const MenuManageDetailScreen = ({menus, updateMenus}: Props) => {
   const [modalVisible, setModalVisible] = useState(false);
   const [currentMenu, setCurrentMenu] = useState<MenuType | null>(null);
 
-  const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
+  const navigation = useNavigation<StackNavigationProp<MenuStackParamList>>();
   const {marketInfo} = useMarket();
   const {profile} = useProfile();
   const {refresh} = useProduct();

--- a/src/screens/MenuManageScreen/MenuManageDetailScreen.tsx
+++ b/src/screens/MenuManageScreen/MenuManageDetailScreen.tsx
@@ -209,38 +209,40 @@ const MenuManageDetailScreen = ({menus, updateMenus}: Props) => {
   };
 
   return (
-    <ScrollView
-      refreshControl={
-        <RefreshControl onRefresh={onRefresh} refreshing={refreshing} />
-      }>
-      {menus.map(menu => (
-        <Menu
-          key={menu.id}
-          menu={menu}
-          onEdit={() => handleEditProduct(menu)}
-          onIncreaseStock={() => handleIncreaseStock(menu)}
-          onDecreaseStock={() => handleDecreaseStock(menu)}
-        />
-      ))}
-      <S.AddProductView>
-        <S.AddButton onPress={handleAddProduct}>
-          <Icon name="plus" size={16} color="rgba(255, 255, 255, 1)" />
-          <S.AddButtonText> 상품 추가하기</S.AddButtonText>
-        </S.AddButton>
-        <S.AddButton onPress={handleGoToDiscountReservation}>
-          <Icon name="percent" size={16} color="rgba(255, 255, 255, 1)" />
-          <S.AddButtonText> 예약 할인 관리</S.AddButtonText>
-        </S.AddButton>
-      </S.AddProductView>
+    <S.Container>
+      <ScrollView
+        refreshControl={
+          <RefreshControl onRefresh={onRefresh} refreshing={refreshing} />
+        }>
+        {menus.map(menu => (
+          <Menu
+            key={menu.id}
+            menu={menu}
+            onEdit={() => handleEditProduct(menu)}
+            onIncreaseStock={() => handleIncreaseStock(menu)}
+            onDecreaseStock={() => handleDecreaseStock(menu)}
+          />
+        ))}
+        <S.AddProductView>
+          <S.AddButton onPress={handleAddProduct}>
+            <Icon name="plus" size={16} color="rgba(255, 255, 255, 1)" />
+            <S.AddButtonText> 상품 추가하기</S.AddButtonText>
+          </S.AddButton>
+          <S.AddButton onPress={handleGoToDiscountReservation}>
+            <Icon name="percent" size={16} color="rgba(255, 255, 255, 1)" />
+            <S.AddButtonText> 예약 할인 관리</S.AddButtonText>
+          </S.AddButton>
+        </S.AddProductView>
 
-      <MenuModal
-        isVisible={modalVisible}
-        onClose={handleModalClose}
-        onSave={handleSaveMenu}
-        initialData={currentMenu}
-        presetTags={getPresetTags(menus)}
-      />
-    </ScrollView>
+        <MenuModal
+          isVisible={modalVisible}
+          onClose={handleModalClose}
+          onSave={handleSaveMenu}
+          initialData={currentMenu}
+          presetTags={getPresetTags(menus)}
+        />
+      </ScrollView>
+    </S.Container>
   );
 };
 

--- a/src/screens/MenuManageScreen/MenuManageDetailScreen.tsx
+++ b/src/screens/MenuManageScreen/MenuManageDetailScreen.tsx
@@ -1,3 +1,4 @@
+import {useNavigation} from '@react-navigation/native';
 import React, {useState} from 'react';
 import {Alert} from 'react-native';
 import {RefreshControl, ScrollView} from 'react-native-gesture-handler';
@@ -28,6 +29,7 @@ const MenuManageDetailScreen = ({menus, updateMenus}: Props) => {
   const [modalVisible, setModalVisible] = useState(false);
   const [currentMenu, setCurrentMenu] = useState<MenuType | null>(null);
 
+  const navigation = useNavigation();
   const {marketInfo} = useMarket();
   const {profile} = useProfile();
   const {refresh} = useProduct();
@@ -37,6 +39,12 @@ const MenuManageDetailScreen = ({menus, updateMenus}: Props) => {
   const handleAddProduct = () => {
     setCurrentMenu(null);
     setModalVisible(true);
+  };
+
+  const handleGoToDiscountReservation = () => {
+    navigation.navigate('Menu', {
+      screen: 'DiscountReservation',
+    });
   };
 
   const handleEditProduct = (menu: MenuType) => {
@@ -65,6 +73,7 @@ const MenuManageDetailScreen = ({menus, updateMenus}: Props) => {
       id: menuData.id,
       image: menuData.image,
       name: menuData.name,
+      reservationStatus: menuData.reservationStatus,
       originPrice: Number(menuData.originPrice.toString().replace(/,/g, '')),
       discountPrice: Number(
         menuData.discountPrice.toString().replace(/,/g, ''),
@@ -99,6 +108,7 @@ const MenuManageDetailScreen = ({menus, updateMenus}: Props) => {
     if (targetMenu.stock === 0) {
       const body: MenuType = {
         id: menuData.id,
+        reservationStatus: null,
         image: menuData.image,
         name: menuData.name,
         originPrice: Number(menuData.originPrice.toString().replace(/,/g, '')),
@@ -148,6 +158,7 @@ const MenuManageDetailScreen = ({menus, updateMenus}: Props) => {
         id: menuData.id,
         image: menuData.image,
         name: menuData.name,
+        reservationStatus: null,
         originPrice: Number(menuData.originPrice.toString().replace(/,/g, '')),
         discountPrice: Number(
           menuData.discountPrice.toString().replace(/,/g, ''),
@@ -212,7 +223,11 @@ const MenuManageDetailScreen = ({menus, updateMenus}: Props) => {
       <S.AddProductView>
         <S.AddButton onPress={handleAddProduct}>
           <Icon name="plus" size={16} color="rgba(255, 255, 255, 1)" />
-          <S.AddButtonText>상품 추가하기</S.AddButtonText>
+          <S.AddButtonText> 상품 추가하기</S.AddButtonText>
+        </S.AddButton>
+        <S.AddButton onPress={handleGoToDiscountReservation}>
+          <Icon name="percent" size={16} color="rgba(255, 255, 255, 1)" />
+          <S.AddButtonText> 예약 할인 관리</S.AddButtonText>
         </S.AddButton>
       </S.AddProductView>
 

--- a/src/types/ProductType.ts
+++ b/src/types/ProductType.ts
@@ -1,7 +1,7 @@
 import {ProductType} from '@ummgoban/shared';
 
 export type MenuType = ProductType & {
-  reservationStatus: 'PENDING' | 'ACTIVE';
+  reservationStatus: 'PENDING' | 'ACTIVE' | null;
 };
 
 export type TagType = {

--- a/src/types/ProductType.ts
+++ b/src/types/ProductType.ts
@@ -1,6 +1,8 @@
 import {ProductType} from '@ummgoban/shared';
 
-export type MenuType = ProductType;
+export type MenuType = ProductType & {
+  reservationStatus: 'PENDING' | 'ACTIVE';
+};
 
 export type TagType = {
   id: number;

--- a/src/types/StackNavigationType.ts
+++ b/src/types/StackNavigationType.ts
@@ -11,7 +11,7 @@ type StackParamType<T> = {
 export interface HomeStackParamList extends ParamListBase {
   MarketInfo: undefined;
   MyPage: undefined;
-  MenuManage: undefined;
+  Menu: undefined;
   Order: undefined;
   Review: undefined;
 }
@@ -44,6 +44,11 @@ export interface ReviewStackParamList extends ParamListBase {
   };
 }
 
+export interface MenuStackParamList extends ParamListBase {
+  MenuManage: undefined;
+  DiscountReservation: undefined;
+}
+
 export interface MyPageStackParamList extends ParamListBase {
   MyPageRoot: undefined;
   Notice: undefined;
@@ -58,4 +63,5 @@ export interface RootStackParamList extends ParamListBase {
   Order: StackParamType<OrderStackParamList>;
   Review: StackParamType<ReviewStackParamList>;
   MyPageRoot: StackParamType<MyPageStackParamList>;
+  Menu: StackParamType<MenuStackParamList>;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->

resolves: #128 

## 📝작업 내용

- 일괄 할인 기능 및 뷰 개발
- 메뉴 관리 페이지에서 접속, 일괄 할인 페이지 -> 할인 별 모달에서 수정 가능

백엔드 요청에 따라 예약 할인이 가게별로 여러개 존재가 가능합니다.

MenuType 내 reservationStatus가 추가되어 해당 컬럼이 null이 아니라면, (일괄 할인 중이거나 예약중이라면)
원가와 할인가 변경을 disabled 처리했습니다.



<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷 (선택)

| **진입화면** | **초기화면** |
| :---: | :---: |
| <img width="360" alt="image" src="https://github.com/user-attachments/assets/b0747f19-b0bb-4988-a38e-403938a59299" /> | <img width="360" alt="image" src="https://github.com/user-attachments/assets/28b32c8a-0d00-4dc5-b0b4-92b65d4ae92f" /> |

| **수정모달** | **생성모달** |
| :---: | :---: |
| <img width="360" alt="image" src="https://github.com/user-attachments/assets/0f35e961-f60d-4942-b831-57d46b6f55b2" /> | <img width="360" alt="image" src="https://github.com/user-attachments/assets/49b9e7b4-fbae-4c8d-9ff7-a6b07028bde8" /> |


<img width="360" alt="image" src="https://github.com/user-attachments/assets/409b2688-fbfe-4f03-b391-7065421bbcf7" />

<img width="360"  alt="image" src="https://github.com/user-attachments/assets/2c5660e8-7ab3-4a4a-86d5-48a1f9b0a956" />





## 💬리뷰 요구사항(선택)

@longrunpc 

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
